### PR TITLE
Fix remaining powerpoint-templates links to PowerPoint

### DIFF
--- a/PMBOK/Process_Groups/Executing/team_performance_assessment_template.md
+++ b/PMBOK/Process_Groups/Executing/team_performance_assessment_template.md
@@ -1,0 +1,196 @@
+# TEAM PERFORMANCE ASSESSMENT
+
+## Document Control Information
+**Document Title:** Team Performance Assessment  
+**Project Name:** [Project Name]  
+**Assessment Period:** [Start Date] to [End Date]  
+**Document Version:** 1.0  
+**Prepared By:** [Author Name, Role]  
+**Preparation Date:** [YYYY-MM-DD]  
+**Last Updated By:** [Name, Role]  
+**Last Revision Date:** [YYYY-MM-DD]  
+
+---
+
+## Purpose and Overview
+
+The Team Performance Assessment is a structured evaluation of individual and collective team performance. It serves to identify strengths, areas for improvement, and development opportunities that will enhance project execution and team effectiveness. Regular assessments help the project manager develop team skills, address performance issues, and improve overall project delivery capabilities.
+
+This document aims to:
+- Evaluate individual and team performance against established criteria
+- Identify skill gaps and development needs
+- Track progress toward performance goals
+- Provide data-driven insights to enhance team effectiveness
+- Document improvement plans and actions taken
+- Recognize achievements and successes
+
+---
+
+## Instructions for Use
+
+1. **Timing**: Conduct assessments at regular intervals (monthly/quarterly) and after significant project milestones
+2. **Preparation**: Gather performance data, update skills matrices, and review previous assessments before meeting
+3. **Process**: Involve team members in the assessment through self-evaluation and peer feedback
+4. **Review**: Discuss the assessment with individual team members and as a team
+5. **Action Planning**: Collaboratively develop improvement plans based on assessment results
+6. **Follow-up**: Monitor progress on action items and development goals
+7. **Integration**: Use insights to inform team development, resource planning, and recognition programs
+
+---
+
+## Individual Performance Assessment
+
+### Individual Performance Metrics
+
+| Team Member | Role | Key Responsibilities | Performance Area | Rating (1-5) | Evidence/Comments |
+|-------------|------|----------------------|------------------|--------------|-------------------|
+| *Jane Smith* | *Senior Developer* | *Backend architecture, Code reviews* | *Technical Quality* | *4* | *Consistently delivers high-quality code with few defects* |
+| *Jane Smith* | *Senior Developer* | *Backend architecture, Code reviews* | *Productivity* | *3* | *Completed 85% of assigned story points* |
+| *Jane Smith* | *Senior Developer* | *Backend architecture, Code reviews* | *Collaboration* | *5* | *Proactively helps junior developers, excellent knowledge sharing* |
+| *Jane Smith* | *Senior Developer* | *Backend architecture, Code reviews* | *Communication* | *4* | *Clear documentation, timely status updates* |
+| *Jane Smith* | *Senior Developer* | *Backend architecture, Code reviews* | *Innovation* | *3* | *Proposed one new approach for performance optimization* |
+| [Name] | [Role] | [Responsibilities] | [Area] | [1-5] | [Comments] |
+
+**Rating Scale:**
+1. Significantly below expectations
+2. Somewhat below expectations
+3. Meets expectations
+4. Exceeds expectations in some areas
+5. Consistently exceeds expectations
+
+### Individual Strengths and Areas for Improvement
+
+| Team Member | Top 3 Strengths | Areas for Improvement | Improvement Actions | Timeline | Support Required |
+|-------------|----------------|----------------------|---------------------|----------|------------------|
+| *Jane Smith* | *1. Technical expertise<br>2. Mentoring skills<br>3. Reliability* | *1. Estimation accuracy<br>2. Work-life balance<br>3. Public speaking* | *1. Attend estimation workshop<br>2. Limit overtime to 5 hours/week<br>3. Present at two team meetings* | *Next 3 months* | *Estimation workshop funding, Presentation coaching* |
+| [Name] | [Strengths] | [Areas] | [Actions] | [Timeline] | [Support] |
+
+---
+
+## Team Performance Assessment
+
+### Team Performance Metrics
+
+| Performance Area | Metrics | Current Performance | Target | Trend | Analysis |
+|------------------|---------|---------------------|--------|-------|----------|
+| **Productivity** | Sprint velocity, Cycle time, Throughput | *Velocity: 45 points/sprint<br>Cycle time: 5.2 days<br>Throughput: 8 items/sprint* | *Velocity: 50 points<br>Cycle time: 4 days<br>Throughput: 10 items* | *Improving* | *Velocity trending upward after onboarding period* |
+| **Quality** | Defect density, Test coverage, Technical debt | *Defect density: 2.3/100 LOC<br>Test coverage: 78%<br>Tech debt: 14 days* | *Defect density: <2/100 LOC<br>Test coverage: >80%<br>Tech debt: <10 days* | *Stable* | *Test coverage improving, but tech debt accumulating* |
+| **Teamwork** | Collaboration index, Knowledge sharing, Conflict resolution | *Collaboration: 3.8/5<br>Knowledge sharing: 3.2/5<br>Conflict resolution: 4.1/5* | *All metrics >4/5* | *Improving* | *Team building activities and pair programming showing positive results* |
+| **Communication** | Meeting effectiveness, Documentation quality, Information flow | *Meeting effectiveness: 3.5/5<br>Documentation: 3.9/5<br>Information flow: 3.3/5* | *All metrics >4/5* | *Mixed* | *Documentation improving but information silos persist* |
+| **Innovation** | New ideas generated, Process improvements, Adaptability | *Ideas: 3/sprint<br>Process improvements: 1/month<br>Adaptability: 3.7/5* | *Ideas: 5/sprint<br>Improvements: 2/month<br>Adaptability: >4/5* | *Stable* | *Innovation has plateaued, consider dedicated innovation time* |
+| **Delivery** | On-time delivery, Budget adherence, Scope completion | *On-time: 87%<br>Budget: 103% of plan<br>Scope: 95% completed* | *On-time: >90%<br>Budget: 100% of plan<br>Scope: 100%* | *Improving* | *Schedule performance improving after initial delays* |
+| [Area] | [Metrics] | [Current] | [Target] | [Trend] | [Analysis] |
+
+### Team Dynamics Assessment
+
+| Aspect | Observations | Impact on Project | Recommendations |
+|--------|--------------|-------------------|-----------------|
+| **Leadership** | *Project Manager provides clear direction but sometimes micromanages technical decisions* | *Some technical team members feel constrained* | *Delegate more technical decisions, focus PM role on removing obstacles* |
+| **Decision Making** | *Decisions often require multiple meetings, some team members hesitant to voice opinions* | *Delayed decisions impact timeline* | *Implement structured decision-making framework, encourage participation* |
+| **Conflict Management** | *Team handles technical disagreements well but interpersonal conflicts are avoided* | *Some underlying tensions affect collaboration* | *Provide conflict resolution training, establish team norms* |
+| **Motivation** | *Team shows high intrinsic motivation for technical challenges, less for documentation and testing* | *Uneven quality across deliverables* | *Rotate less desirable tasks, recognize contributions in all areas* |
+| **Cohesion** | *Strong bonds within functional groups, less cross-functional integration* | *Handoffs between groups create delays* | *Implement cross-functional pairing, organize team building across groups* |
+| [Aspect] | [Observations] | [Impact] | [Recommendations] |
+
+### Team Strengths and Areas for Improvement
+
+| Team Strengths | Examples/Evidence | Team Improvement Areas | Improvement Actions | Timeline | Success Measures |
+|----------------|-------------------|------------------------|---------------------|----------|------------------|
+| *Technical expertise* | *Successfully implemented complex architectural changes with minimal disruption* | *Cross-functional knowledge* | *Implement learning sessions, rotation program* | *Q3 2025* | *Each member can support at least two functional areas* |
+| *Problem-solving* | *Quickly resolved critical production issue through collaborative troubleshooting* | *Proactive risk management* | *Weekly risk identification workshop* | *Start next sprint* | *50% reduction in unforeseen issues* |
+| *Commitment to quality* | *Maintained >95% test coverage despite tight deadlines* | *Efficiency/productivity* | *Process optimization, eliminate waste* | *Next 2 months* | *15% increase in velocity without quality reduction* |
+| [Strength] | [Evidence] | [Area] | [Actions] | [Timeline] | [Measures] |
+
+---
+
+## Skills Assessment Matrix
+
+### Technical Skills Matrix
+
+| Team Member | Skill 1<br>[Technology] | Skill 2<br>[Technology] | Skill 3<br>[Technology] | Skill 4<br>[Technology] | Skill 5<br>[Technology] |
+|-------------|-------------------------|-------------------------|-------------------------|-------------------------|-------------------------|
+| *Jane Smith* | *5 - Expert<br>[Java]* | *4 - Advanced<br>[SQL]* | *3 - Intermediate<br>[AWS]* | *2 - Basic<br>[React]* | *1 - Awareness<br>[ML]* |
+| *John Doe* | *3 - Intermediate<br>[Java]* | *5 - Expert<br>[React]* | *4 - Advanced<br>[CSS]* | *3 - Intermediate<br>[AWS]* | *3 - Intermediate<br>[Node.js]* |
+| [Name] | [Rating - Level] | [Rating - Level] | [Rating - Level] | [Rating - Level] | [Rating - Level] |
+
+**Skill Level Definitions:**
+1. **Awareness**: Basic awareness of concepts but no practical experience
+2. **Basic**: Limited experience, requires significant guidance
+3. **Intermediate**: Working knowledge, can perform tasks with some guidance
+4. **Advanced**: Deep understanding, can work independently and solve complex problems
+5. **Expert**: Comprehensive and authoritative knowledge, can teach others and innovate
+
+### Soft Skills Matrix
+
+| Team Member | Leadership | Communication | Problem Solving | Teamwork | Time Management | Adaptability |
+|-------------|------------|---------------|----------------|----------|----------------|--------------|
+| *Jane Smith* | *4* | *4* | *5* | *4* | *3* | *4* |
+| *John Doe* | *3* | *5* | *4* | *5* | *4* | *3* |
+| [Name] | [1-5] | [1-5] | [1-5] | [1-5] | [1-5] | [1-5] |
+
+### Project-Specific Skills Matrix
+
+| Team Member | Domain Knowledge | Project Methodology | Tools Proficiency | Regulatory Compliance | Stakeholder Management |
+|-------------|-----------------|---------------------|-------------------|------------------------|------------------------|
+| *Jane Smith* | *4* | *3* | *4* | *3* | *4* |
+| *John Doe* | *3* | *4* | *3* | *2* | *5* |
+| [Name] | [1-5] | [1-5] | [1-5] | [1-5] | [1-5] |
+
+### Team Skills Gap Analysis
+
+| Skill Area | Current Capability | Required Capability | Gap | Impact on Project | Mitigation Strategy |
+|------------|-------------------|---------------------|-----|-------------------|---------------------|
+| *Cloud Security* | *2.3 average* | *4.0 required* | *1.7* | *High - Critical for compliance* | *External training, hire specialist consultant* |
+| *UI/UX Design* | *2.8 average* | *3.5 required* | *0.7* | *Medium - Affects user satisfaction* | *Internal workshops with design team* |
+| *Agile Practices* | *3.2 average* | *4.0 required* | *0.8* | *Medium - Affects process efficiency* | *Agile coach, process improvements* |
+| [Skill] | [Current] | [Required] | [Gap] | [Impact] | [Strategy] |
+
+---
+
+## Performance Improvement Plans
+
+### Individual Development Plans
+
+| Team Member | Development Goal | Success Criteria | Actions | Timeline | Resources Required | Progress Updates |
+|-------------|------------------|------------------|---------|----------|-------------------|------------------|
+| *Jane Smith* | *Advance AWS certification* | *Obtain AWS Solutions Architect certification* | *1. Complete online course<br>2. Practice exams<br>3. Take certification test* | *By Q4 2025* | *Training budget: $500<br>Study time: 4 hours/week* | *Course 75% complete<br>Practice score: 82%* |
+| *John Doe* | *Improve estimation accuracy* | *Estimates within 15% of actuals* | *1. Attend estimation workshop<br>2. Use historical data<br>3. Review/adjust technique* | *Next 3 sprints* | *Workshop attendance<br>Access to metrics* | *Workshop completed<br>Accuracy improved to 25%* |
+| [Name] | [Goal] | [Criteria] | [Actions] | [Timeline] | [Resources] | [Progress] |
+
+### Team Improvement Initiatives
+
+| Improvement Area | Current State | Desired State | Initiative | Owner | Timeline | Success Measures | Status |
+|------------------|--------------|---------------|-----------|-------|----------|------------------|--------|
+| *Knowledge Sharing* | *Information silos, dependent on key individuals* | *Distributed knowledge, documentation* | *1. Implement pair programming<br>2. Weekly knowledge sharing sessions<br>3. Create documentation standards* | *Technical Lead* | *Q3 2025* | *Bus factor improves from 1 to 3<br>Documentation coverage >90%* | *In progress - 40% complete* |
+| *Meeting Efficiency* | *Too many meetings, often run over time* | *Focused, efficient meetings* | *1. Implement meeting guidelines<br>2. Train meeting facilitators<br>3. Review meeting necessity quarterly* | *Scrum Master* | *Start next sprint* | *25% reduction in meeting time<br>Meeting satisfaction >4/5* | *Planning phase* |
+| [Area] | [Current] | [Desired] | [Initiative] | [Owner] | [Timeline] | [Measures] | [Status] |
+
+---
+
+## Recognition and Achievements
+
+### Individual Achievements
+
+| Team Member | Achievement | Impact | Recognition Method |
+|-------------|------------|--------|-------------------|
+| *Jane Smith* | *Led critical data migration with zero downtime* | *Prevented potential $50K revenue loss, maintained customer trust* | *Spotlight in company newsletter, $500 spot bonus* |
+| *John Doe* | *Mentored two junior developers to independence* | *Increased team capacity, improved quality* | *Recognition in team meeting, professional development opportunity* |
+| [Name] | [Achievement] | [Impact] | [Recognition] |
+
+### Team Achievements
+
+| Achievement | Date | Impact | Recognition |
+|-------------|------|--------|------------|
+| *Delivered Phase 1 two weeks ahead of schedule* | *YYYY-MM-DD* | *Early value delivery, positive stakeholder feedback* | *Team celebration lunch, executive acknowledgment* |
+| *Reduced system response time by 40%* | *YYYY-MM-DD* | *Improved user experience, reduced operational costs* | *Case study publication, team innovation award* |
+| [Achievement] | [Date] | [Impact] | [Recognition] |
+
+---
+
+## Integration with Project Management Processes
+
+| Process Area | Integration Points | How to Use Assessment Data |
+|--------------|-------------------|---------------------------|
+| **Resource Management** | - Skills matrix informs resource allocation<br>- Performance data influences role assignments<br>- Development plans identify future capabilities | - Assign team members based on skills and performance<br>- Balance teams with complementary strengths<br>- Plan for skill development to meet future needs |
+| **Communications Management** | - Identifies communication strengths/weaknesses<br>- Highlights information flow issues<br>- Documents team dynamics | - Tailor communications based on
+

--- a/PMBOK/Process_Groups/Initiating/stakeholder_register_template.md
+++ b/PMBOK/Process_Groups/Initiating/stakeholder_register_template.md
@@ -1,0 +1,133 @@
+# STAKEHOLDER REGISTER
+
+## Document Control Information
+**Document Title:** Stakeholder Register  
+**Project Name:** [Project Name]  
+**Document Version:** 1.0  
+**Prepared By:** [Author Name, Role]  
+**Preparation Date:** [YYYY-MM-DD]  
+**Last Updated By:** [Name, Role]  
+**Last Revision Date:** [YYYY-MM-DD]  
+
+---
+
+## Purpose and Overview
+
+The Stakeholder Register is a project document that identifies and categorizes individuals, groups, or organizations that could impact or be impacted by project decisions, activities, or outcomes. This document serves as a central repository of stakeholder information that helps the project team understand stakeholder relationships, influence, interests, expectations, and appropriate engagement strategies.
+
+This register should be:
+- Created during project initiation and regularly updated throughout the project lifecycle
+- Used to guide stakeholder communication and engagement planning
+- Maintained as confidential when containing sensitive information about stakeholders
+- Referenced when making key project decisions to consider stakeholder impacts
+
+---
+
+## Instructions for Use
+
+1. **Identification**: Conduct stakeholder analysis sessions with the project team to identify all relevant stakeholders.
+2. **Classification**: Categorize stakeholders based on their influence, interest, and impact on the project.
+3. **Documentation**: Record all relevant information in the register using the template below.
+4. **Analysis**: Analyze stakeholder relationships, potential conflicts, and overall influence patterns.
+5. **Strategy Development**: Create appropriate engagement strategies based on stakeholder characteristics.
+6. **Regular Updates**: Review and update the register as new stakeholders are identified or existing stakeholder information changes.
+
+---
+
+## Stakeholder Information Matrix
+
+| ID | Name | Position/Role | Organization | Category | Contact Information | Project Role |
+|----|------|---------------|--------------|----------|---------------------|--------------|
+| S-01 | *Jane Smith* | *CEO* | *Example Corp* | *Executive* | *jane.smith@example.com<br>555-123-4567* | *Project Sponsor* |
+| S-02 | *John Doe* | *IT Director* | *Example Corp* | *Management* | *john.doe@example.com<br>555-234-5678* | *Technical Advisor* |
+| S-03 | *Maria Garcia* | *Finance Manager* | *Example Corp* | *Management* | *maria.garcia@example.com<br>555-345-6789* | *Budget Approval* |
+| S-04 | *Team-X Representatives* | *Various* | *Vendor Inc.* | *External* | *team-x@vendor.com* | *Solution Provider* |
+| [ID] | [Full Name] | [Job Title/Position] | [Company/Department] | [Internal/External/Management/etc.] | [Email/Phone] | [Role on project] |
+
+## Stakeholder Assessment
+
+| ID | Influence<br>(H/M/L) | Interest<br>(H/M/L) | Impact on Project<br>(H/M/L) | Impact by Project<br>(H/M/L) | Current Engagement | Desired Engagement | Priority<br>(H/M/L) |
+|----|----------------------|---------------------|----------------------------|----------------------------|-------------------|-------------------|---------------------|
+| S-01 | *H* | *H* | *H* | *M* | *Leading* | *Leading* | *H* |
+| S-02 | *H* | *M* | *H* | *H* | *Supportive* | *Leading* | *H* |
+| S-03 | *M* | *L* | *M* | *L* | *Neutral* | *Supportive* | *M* |
+| S-04 | *M* | *H* | *H* | *M* | *Supportive* | *Leading* | *H* |
+| [ID] | [H/M/L] | [H/M/L] | [H/M/L] | [H/M/L] | [Unaware/Resistant/Neutral/Supportive/Leading] | [Desired level] | [H/M/L] |
+
+**Legend for Engagement Levels:**
+- **Unaware**: No knowledge of project or impacts
+- **Resistant**: Aware of project but resistant to change
+- **Neutral**: Aware of project but neither supportive nor resistant
+- **Supportive**: Aware of project and supportive of change
+- **Leading**: Aware of project and actively engaged in ensuring success
+
+## Communication Preferences and Requirements
+
+| ID | Communication Frequency | Preferred Method | Key Information Needs | Language Requirements | Special Considerations |
+|----|-------------------------|------------------|------------------------|-----------------------|------------------------|
+| S-01 | *Weekly* | *Executive Summary, In-person meeting* | *Progress against objectives, Budget updates* | *English* | *Time-sensitive responses required* |
+| S-02 | *Bi-weekly* | *Detailed Report, Email* | *Technical specifications, Resource allocation* | *English* | *Prefers data visualizations* |
+| S-03 | *Monthly* | *Financial Report, Email* | *Budget tracking, Cost forecasts* | *English* | *Requires advance notice for meetings* |
+| S-04 | *Weekly* | *Video call, Status report* | *Integration points, Technical requirements* | *English* | *Time zone differences (PST)* |
+| [ID] | [Daily/Weekly/Bi-weekly/Monthly/As needed] | [Email/Meeting/Call/Report] | [Specific information required] | [Language] | [Any special needs] |
+
+## Stakeholder Engagement Strategy
+
+| ID | Engagement Approach | Key Messages | Response to Concerns | Relationship Owner | Success Criteria |
+|----|---------------------|--------------|----------------------|-------------------|------------------|
+| S-01 | *Regular executive briefings, Decision checkpoints* | *Strategic alignment, ROI, Organizational impact* | *Provide alternative scenarios with cost-benefit analysis* | *Project Manager* | *Continued sponsorship, Timely decision-making* |
+| S-02 | *Technical deep dives, Inclusion in architecture decisions* | *Technical benefits, Resource optimization, Innovation opportunities* | *Provide technical research, Proof of concepts* | *Technical Lead* | *Technical approval, Resource allocation* |
+| S-03 | *Transparent financial reporting, Early escalation of budget issues* | *Financial controls, Budget adherence, Cost tracking* | *Present mitigation options with financial analysis* | *Project Manager* | *Timely budget approvals, Financial support* |
+| S-04 | *Clear requirements documentation, Regular integration meetings* | *Integration timelines, Technical requirements, Mutual success factors* | *Document change requests, Impact analysis* | *Integration Lead* | *Quality deliverables, Adherence to schedule* |
+| [ID] | [Strategy for engagement] | [Key information to communicate] | [How to address concerns] | [Team member responsible] | [How to measure effective engagement] |
+
+## Stakeholder Relationships and Groups
+
+*Use this section to document relationships between stakeholders, including coalitions, dependencies, or conflicts.*
+
+**Key Stakeholder Groups:**
+1. **Executive Leadership**: S-01, [Others]
+   - *Decision rights: Final approval on scope, budget, and timeline*
+   - *Group dynamics: Meet monthly as steering committee*
+
+2. **Technical Implementation Team**: S-02, S-04, [Others]
+   - *Decision rights: Technical approach and solution design*
+   - *Group dynamics: Collaborative but S-02 has final authority over technical decisions*
+
+3. **Financial Oversight**: S-03, [Others]
+   - *Decision rights: Budget approval, financial reporting approval*
+   - *Group dynamics: Report to CFO, require formal documentation*
+
+**Stakeholder Relationship Map:**
+*Consider including a simple visualization of stakeholder relationships here or reference an attached diagram.*
+
+## Change History
+
+| Version | Date | Modified By | Description of Changes |
+|---------|------|-------------|------------------------|
+| 0.1 | [YYYY-MM-DD] | [Name] | Initial draft |
+| 1.0 | [YYYY-MM-DD] | [Name] | First complete version |
+| [Version] | [Date] | [Name] | [Description] |
+
+---
+
+## Related Templates
+
+- [Project Charter](./project_charter_template.md) - Use in conjunction with this register
+- [Communication Plan](../../Templates/communication_plan_template.md) - Develops detailed communication approaches based on stakeholder needs
+- [Risk Register](../../Templates/risk_register_template.md) - Consider stakeholder-related risks
+
+---
+
+## Notes and Guidelines
+
+1. **Confidentiality**: This document may contain sensitive information about stakeholders and should be treated as confidential.
+2. **Regular Updates**: The Stakeholder Register should be reviewed and updated at least monthly or when significant changes occur.
+3. **Completeness**: Ensure all stakeholders are included, even those who may initially appear to have minimal involvement.
+4. **Objectivity**: Maintain professional, objective language when describing stakeholders and their attributes.
+5. **Engagement Levels**: Monitor changes in engagement levels throughout the project lifecycle.
+
+---
+
+**Reminder:** Effective stakeholder engagement is critical to project success. This register is a tool to help understand and manage stakeholder relationships, not simply a documentation exercise.
+

--- a/PMBOK/Process_Groups/Planning/project_schedule_template.md
+++ b/PMBOK/Process_Groups/Planning/project_schedule_template.md
@@ -1,0 +1,310 @@
+# PROJECT SCHEDULE
+
+## Document Control Information
+**Document Title:** Project Schedule  
+**Project Name:** [Project Name]  
+**Document Version:** 1.0  
+**Prepared By:** [Author Name, Role]  
+**Preparation Date:** [YYYY-MM-DD]  
+**Last Updated By:** [Name, Role]  
+**Last Revision Date:** [YYYY-MM-DD]  
+
+---
+
+## Purpose and Overview
+
+The Project Schedule is a time-based representation of project activities that documents when work will be performed and deliverables will be produced. It serves as a tool for communication, resource management, progress tracking, and forecasting project completion.
+
+This document serves to:
+- Define the timeline for project execution
+- Establish the sequence and dependencies between activities
+- Assign resources to activities
+- Identify the critical path for project completion
+- Establish a baseline for measuring schedule performance
+- Communicate timing expectations to all stakeholders
+
+---
+
+## Instructions for Use
+
+1. Use this template after completing the Work Breakdown Structure (WBS)
+2. Follow the schedule development process outlined in Section III
+3. Complete each section of the schedule template with project-specific information
+4. Review the schedule with relevant stakeholders for validation and approval
+5. Baseline the schedule once approved
+6. Update the schedule regularly throughout project execution
+7. Document schedule changes according to the change control process
+
+---
+
+## Schedule Development Process
+
+### Schedule Development Workflow
+
+1. **Define Activities**: Identify specific activities required to produce project deliverables
+2. **Sequence Activities**: Determine logical relationships between activities
+3. **Estimate Resources**: Determine type and quantity of resources required for each activity
+4. **Estimate Durations**: Estimate time required to complete each activity
+5. **Develop Schedule**: Create schedule model using activities, sequences, resources, and durations
+6. **Validate Schedule**: Review schedule with team and stakeholders
+7. **Analyze Schedule**: Perform critical path analysis, identify buffer/contingency needs
+8. **Optimize Schedule**: Compress or adjust schedule as needed to meet constraints
+9. **Baseline Schedule**: Establish approved schedule as the performance measurement baseline
+10. **Control Schedule**: Monitor progress, manage changes, and update as needed
+
+### Activity Definition Guidelines
+
+Activities should:
+- Derive directly from work packages in the WBS
+- Have clear start and finish points
+- Be definable at a level of detail appropriate for effective management
+- Have durations within a manageable time frame (typically 1 day to 2 weeks)
+- Be assignable to specific individuals or teams
+- Have measurable progress indicators
+
+### Activity Sequencing Methods
+
+| Relationship | Description | Notation | Example |
+|--------------|-------------|----------|---------|
+| Finish-to-Start (FS) | Activity B cannot start until Activity A finishes | A FS B | Testing (B) cannot start until development (A) is complete |
+| Start-to-Start (SS) | Activity B cannot start until Activity A starts | A SS B | Document writing (B) can start after requirements gathering (A) begins |
+| Finish-to-Finish (FF) | Activity B cannot finish until Activity A finishes | A FF B | System testing (B) cannot finish until bug fixing (A) is complete |
+| Start-to-Finish (SF) | Activity B cannot finish until Activity A starts | A SF B | Old system support (B) ends when new system implementation (A) starts |
+| Leads and Lags | Time modifiers for relationships | FS+5 or FS-3 | Install software (B) can start 2 days before hardware setup (A) completes (FS-2) |
+
+### Duration Estimation Techniques
+
+1. **Expert Judgment**: Based on experience with similar activities
+2. **Analogous Estimating**: Using actual durations from similar activities in past projects
+3. **Parametric Estimating**: Using statistical relationships between historical data and variables
+4. **Three-Point Estimating (PERT)**: Using optimistic (O), most likely (M), and pessimistic (P) estimates
+   - Triangular Distribution: (O + M + P) / 3
+   - Beta Distribution (PERT): (O + 4M + P) / 6
+5. **Bottom-up Estimating**: Estimating individual components then aggregating
+6. **Reserve Analysis**: Adding buffer time (contingency reserves) for known risks
+
+---
+
+## Schedule Components
+
+### Activity Attributes Template
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Activity ID** | Unique identifier | ACT-1001 |
+| **Activity Name** | Descriptive name | Database Design |
+| **WBS Reference** | Related WBS element | 1.3.2.1 |
+| **Description** | Detailed description of work | Creating logical and physical database design for the system |
+| **Predecessor(s)** | Activities that must finish first | ACT-1000 (Requirements Analysis) |
+| **Successor(s)** | Activities that follow | ACT-1002 (Database Implementation) |
+| **Relationship Type** | Type of dependency | FS (Finish-to-Start) |
+| **Lead/Lag** | Time adjustment to relationship | +2d (2 day lag) |
+| **Duration** | Estimated time to complete | 5 days |
+| **Effort** | Person-hours required | 40 hours |
+| **Start Date** | Scheduled start date | YYYY-MM-DD |
+| **Finish Date** | Scheduled finish date | YYYY-MM-DD |
+| **Resources** | People or materials assigned | John Smith (Database Architect) |
+| **Resource Units** | Allocation percentage | 100% |
+| **Constraints** | Fixed dates or deadlines | Must finish by YYYY-MM-DD |
+| **Assumptions** | Underlying assumptions | Resource has SQL Server experience |
+| **Priority** | Relative importance | High/Medium/Low |
+| **Status** | Current state | Not Started/In Progress/Complete |
+| **% Complete** | Completion percentage | 0% |
+| **Notes** | Additional information | Requires vendor input on data structure |
+
+### Activity List Template
+
+| Activity ID | Activity Name | WBS Reference | Description | Duration | Predecessors | Resources | Status |
+|-------------|--------------|--------------|-------------|----------|--------------|-----------|--------|
+| *ACT-1000* | *Requirements Analysis* | *1.2.1* | *Gather and document requirements* | *10d* | *None* | *Business Analyst* | *Complete* |
+| *ACT-1001* | *Database Design* | *1.3.2.1* | *Design database schema* | *5d* | *ACT-1000 FS* | *Database Architect* | *In Progress* |
+| *ACT-1002* | *Database Implementation* | *1.3.2.2* | *Create and configure database* | *3d* | *ACT-1001 FS+2d* | *Database Developer* | *Not Started* |
+| [Activity ID] | [Activity Name] | [WBS Reference] | [Description] | [Duration] | [Predecessors] | [Resources] | [Status] |
+
+### Milestone List Template
+
+| Milestone ID | Milestone Name | Description | Planned Date | Actual Date | Status | Owner |
+|--------------|---------------|-------------|--------------|------------|--------|-------|
+| *MS-001* | *Project Kickoff* | *Formal start of project* | *YYYY-MM-DD* | *YYYY-MM-DD* | *Complete* | *Project Manager* |
+| *MS-002* | *Requirements Approved* | *Requirements signed off by stakeholders* | *YYYY-MM-DD* | *YYYY-MM-DD* | *Complete* | *Business Analyst* |
+| *MS-003* | *Design Complete* | *All design documents approved* | *YYYY-MM-DD* | *N/A* | *Pending* | *Solution Architect* |
+| [Milestone ID] | [Milestone Name] | [Description] | [Planned Date] | [Actual Date] | [Status] | [Owner] |
+
+---
+
+## Schedule Presentation Formats
+
+### Gantt Chart Format
+
+A Gantt chart displays activities as horizontal bars along a timeline, with:
+- Activities listed vertically on the left
+- Timeline displayed horizontally
+- Activity durations shown as horizontal bars
+- Dependencies displayed as arrows between activities
+- Milestones marked as diamonds
+- Critical path activities typically highlighted
+- Resources often displayed alongside activities
+
+*Note: Create Gantt charts using project management software like Microsoft Project, Smartsheet, or similar tools.*
+
+**Example Gantt Chart Elements:**
+```
+Task Name                 | Duration | Start      | Finish     | Predecessors | Resources
+--------------------------|----------|------------|------------|--------------|----------
+1. Project Initiation     | 10 days  | 2025-01-01 | 2025-01-14 |              | PM
+   1.1 Project Charter    | 5 days   | 2025-01-01 | 2025-01-07 |              | PM
+   1.2 Stakeholder Reg.   | 3 days   | 2025-01-08 | 2025-01-10 | 1.1          | PM
+   1.3 Kickoff Meeting    | 2 days   | 2025-01-13 | 2025-01-14 | 1.2          | PM, Team
+2. Project Planning       | 15 days  | 2025-01-15 | 2025-02-04 | 1            |
+   2.1 Requirements       | 10 days  | 2025-01-15 | 2025-01-28 |              | BA
+   2.2 Design             | 5 days   | 2025-01-29 | 2025-02-04 | 2.1          | Designer
+...
+```
+
+### Network Diagram Format
+
+A network diagram (precedence diagram) shows the logical relationships between activities:
+- Activities represented as nodes (boxes)
+- Dependencies shown as arrows between nodes
+- Early start/finish and late start/finish times displayed
+- Critical path highlighted
+- Float/slack time indicated
+
+**Example Network Diagram Box:**
+```
+┌───────────────────────────┐
+│ Activity ID: ACT-1001     │
+│ Name: Database Design     │
+│                           │
+│ Duration: 5 days          │
+│ ES: 11  EF: 15            │
+│ LS: 11  LF: 15            │
+│ Float: 0 (Critical Path)  │
+└───────────────────────────┘
+```
+
+### Calendar View
+
+A calendar view displays project activities on a standard calendar:
+- Activities scheduled on specific dates
+- Multiple activities can appear on the same day
+- Resource allocations can be overlaid
+- Useful for resource scheduling and availability visualization
+
+### Tabular Schedule
+
+| Activity | Start Date | End Date | Duration | Lead | Team Members | % Complete | Status |
+|----------|------------|----------|----------|------|--------------|------------|--------|
+| [Activity] | [YYYY-MM-DD] | [YYYY-MM-DD] | [Duration] | [Lead] | [Team] | [Completion %] | [Status] |
+
+---
+
+## Resource Considerations
+
+### Resource Loading Chart Template
+
+Resource loading charts display resource allocation over time.
+
+**Sample Resource Loading Table:**
+
+| Resource Name | Role | Week 1 | Week 2 | Week 3 | Week 4 | Week 5 | Week 6 | Total Hours |
+|---------------|------|--------|--------|--------|--------|--------|--------|-------------|
+| *Jane Smith* | *Project Manager* | *20h* | *20h* | *20h* | *20h* | *20h* | *20h* | *120h* |
+| *John Doe* | *Developer* | *40h* | *40h* | *40h* | *40h* | *20h* | *10h* | *190h* |
+| *Alice Brown* | *Designer* | *10h* | *30h* | *40h* | *20h* | *0h* | *0h* | *100h* |
+| [Resource Name] | [Role] | [Hours] | [Hours] | [Hours] | [Hours] | [Hours] | [Hours] | [Sum] |
+
+### Resource Leveling Considerations
+
+Resource leveling aims to resolve over-allocations while minimizing impact on the project schedule:
+
+1. **Techniques for Resource Leveling:**
+   - Delaying non-critical activities within their float
+   - Splitting activities to allow for interruptions
+   - Adjusting resource assignments across activities
+   - Extending activity durations but using fewer resources
+   - Adding resources to critical activities (crashing)
+
+2. **Impact Documentation:**
+   
+   | Activity | Original Duration | Leveled Duration | Delay | Justification | Impact on End Date |
+   |----------|-------------------|------------------|-------|---------------|-------------------|
+   | [Activity] | [Duration] | [New Duration] | [Delay] | [Reason] | [Impact] |
+
+3. **Resource Leveling Priority Rules:**
+   - Critical activities first
+   - Activities with least float first
+   - Higher priority activities first
+   - Resource-intensive activities first
+   - Activities with preferred sequence first
+
+---
+
+## Schedule Baseline and Control
+
+### Schedule Baseline
+
+The schedule baseline is the approved version of the project schedule that serves as the basis for comparison to actual results. Document the baseline approval as follows:
+
+**Baseline Approval:**
+
+| Item | Details |
+|------|---------|
+| **Baseline Version:** | [Version number] |
+| **Baseline Date:** | [YYYY-MM-DD] |
+| **Project Start Date:** | [YYYY-MM-DD] |
+| **Project End Date:** | [YYYY-MM-DD] |
+| **Total Duration:** | [Duration] |
+| **Critical Path Duration:** | [Duration] |
+| **Schedule Reserve:** | [Duration] |
+| **Approved By:** | [Name, Title] |
+| **Approval Date:** | [YYYY-MM-DD] |
+| **Comments:** | [Any special conditions or notes about the baseline] |
+
+### Schedule Control Process
+
+1. **Progress Tracking**:
+   - Update activity status (Not Started, In Progress, Complete)
+   - Record actual start and finish dates
+   - Update percent complete
+   - Document actual work/duration
+
+2. **Performance Measurement**:
+   - Schedule variance (SV) = Earned Value (EV) - Planned Value (PV)
+   - Schedule performance index (SPI) = EV / PV
+   - Forecast schedule using SPI trends
+
+3. **Schedule Change Control**:
+
+   | Field | Description |
+   |-------|-------------|
+   | **Change Request ID:** | [Unique identifier] |
+   | **Description of Change:** | [What is changing in the schedule] |
+   | **Reason for Change:** | [Why the change is needed] |
+   | **Impact on Schedule:** | [Days added/removed, effect on critical path] |
+   | **Impact on Resources:** | [Additional resources needed or resource changes] |
+   | **Impact on Cost:** | [Cost increase/decrease due to schedule change] |
+   | **Impact on Scope/Quality:** | [Any effects on deliverables or quality] |
+   | **Alternatives Considered:** | [Other options that were evaluated] |
+   | **Recommendation:** | [Approve/Reject recommendation] |
+   | **Approvals Required:** | [Names/roles needed to approve] |
+   | **Decision:** | [Approved/Rejected] |
+   | **Decision Date:** | [YYYY-MM-DD] |
+
+4. **Schedule Updates and Communication**:
+   - Update schedule with approved changes
+   - Maintain version control
+   - Communicate changes to stakeholders
+   - Document lessons learned
+
+---
+
+## Integration with Other Project Documents
+
+| Document | Integration Point |
+|----------|-------------------|
+| **Work Breakdown Structure** | Activities derive from WBS work packages; WBS codes link activities to scope elements |
+| **Resource Management Plan** | Resources assigned to activities based on availability in Resource Management Plan |
+| **Cost Management Plan** | Activity durations and resource assignments drive cost estimates |
+| **Risk Register** | Schedule risks identified in Risk Register may require buf
+

--- a/PMBOK/Process_Groups/Planning/work_breakdown_structure_template.md
+++ b/PMBOK/Process_Groups/Planning/work_breakdown_structure_template.md
@@ -1,0 +1,302 @@
+# WORK BREAKDOWN STRUCTURE (WBS)
+
+## Document Control Information
+**Document Title:** Work Breakdown Structure  
+**Project Name:** [Project Name]  
+**Document Version:** 1.0  
+**Prepared By:** [Author Name, Role]  
+**Preparation Date:** [YYYY-MM-DD]  
+**Last Updated By:** [Name, Role]  
+**Last Revision Date:** [YYYY-MM-DD]  
+
+---
+
+## Purpose and Overview
+
+The Work Breakdown Structure (WBS) is a hierarchical decomposition of the total scope of work to be carried out by the project team to accomplish the project objectives and create the required deliverables. It organizes and defines the total scope of the project and represents the work specified in the currently approved project scope statement.
+
+This document serves as:
+- A foundational scope management tool that defines all project work elements
+- A framework for detailed cost estimation and schedule development
+- A basis for performance measurement and project control
+- A communication tool for stakeholders to visualize project scope
+
+---
+
+## Instructions for Use
+
+1. Begin with the approved project scope statement
+2. Conduct WBS development workshops with appropriate stakeholders
+3. Decompose project deliverables into work packages using this template
+4. Create WBS Dictionary entries for each work package
+5. Verify completeness using the 100% rule (all children must represent 100% of parent)
+6. Review and obtain approval from key stakeholders
+7. Integrate with project schedule, resource assignments, and cost estimates
+8. Baseline the WBS and place under change control
+
+---
+
+## WBS Development Guidelines
+
+### Decomposition Process
+
+1. **Identify major deliverables** from the project scope statement
+2. **Determine how each deliverable will be produced** (what work is required)
+3. **Decompose higher-level items** into smaller, manageable components
+4. **Continue decomposition** until reaching work packages that:
+   - Can be realistically estimated for cost and duration
+   - Can be assigned to a single responsible party
+   - Can be completed in a reasonable timeframe (typically 2-80 hours of effort)
+   - Have measurable progress and distinct completion criteria
+5. **Verify decomposition** is sufficient and comprehensive
+
+### Numbering Convention
+
+- **Level 1**: Project Name (1.0)
+- **Level 2**: Major Deliverable/Phase (1.1, 1.2, etc.)
+- **Level 3**: Sub-deliverable (1.1.1, 1.1.2, etc.)
+- **Level 4**: Work Package Components (1.1.1.1, 1.1.1.2, etc.)
+- **Level 5**: Activities (if needed) (1.1.1.1.1, 1.1.1.1.2, etc.)
+
+### Coding Structure
+
+Using a proper coding structure enables better tracking, integration with other systems, and filtered reporting:
+
+| Level | Format | Example | Description |
+|-------|--------|---------|-------------|
+| 1 | Project ID | PRJ-001 | Unique project identifier |
+| 2 | Major Deliverable | PRJ-001.01 | Major phases or components |
+| 3 | Sub-deliverable | PRJ-001.01.01 | Significant components of major deliverables |
+| 4 | Work Package | PRJ-001.01.01.01 | Assignable units of work |
+| 5+ | Activity (optional) | PRJ-001.01.01.01.01 | Detailed tasks within work packages |
+
+---
+
+## WBS Template Formats
+
+### Hierarchical Outline Format
+
+This format uses indentation to show the WBS hierarchy:
+
+```
+1.0 [Project Name]
+  1.1 [Major Deliverable/Phase 1]
+    1.1.1 [Sub-deliverable 1]
+      1.1.1.1 [Work Package 1]
+      1.1.1.2 [Work Package 2]
+    1.1.2 [Sub-deliverable 2]
+      1.1.2.1 [Work Package 1]
+      1.1.2.2 [Work Package 2]
+  1.2 [Major Deliverable/Phase 2]
+    1.2.1 [Sub-deliverable 1]
+      1.2.1.1 [Work Package 1]
+      1.2.1.2 [Work Package 2]
+```
+
+### Tabular Format
+
+| WBS Code | Description | Level | Parent | Responsible | Duration (days) | Effort (hours) |
+|----------|-------------|-------|--------|-------------|-----------------|----------------|
+| 1.0 | *Project Name* | 1 | - | *PM* | *120* | *1920* |
+| 1.1 | *Major Deliverable 1* | 2 | 1.0 | *PM* | *30* | *480* |
+| 1.1.1 | *Sub-deliverable 1.1* | 3 | 1.1 | *Team Lead A* | *15* | *240* |
+| 1.1.1.1 | *Work Package 1.1.1* | 4 | 1.1.1 | *Team Member 1* | *5* | *80* |
+| 1.1.1.2 | *Work Package 1.1.2* | 4 | 1.1.1 | *Team Member 2* | *10* | *160* |
+| 1.1.2 | *Sub-deliverable 1.2* | 3 | 1.1 | *Team Lead B* | *15* | *240* |
+| 1.1.2.1 | *Work Package 1.2.1* | 4 | 1.1.2 | *Team Member 3* | *7* | *112* |
+| 1.1.2.2 | *Work Package 1.2.2* | 4 | 1.1.2 | *Team Member 4* | *8* | *128* |
+
+### Graphical Format (Tree Structure)
+
+The WBS can also be presented as a graphical tree structure where:
+- The project appears at the top (Level 1)
+- Major deliverables/phases appear below (Level 2)
+- Continuing decomposition downward through the levels
+- Work packages as terminal nodes
+
+*Note: Create and attach a graphical representation using a tool like Microsoft Project, WBS Chart Pro, Visio, or similar.*
+
+---
+
+## Example WBS for Software Implementation Project
+
+### Hierarchical Outline Example
+
+```
+1.0 CRM System Implementation Project
+  1.1 Project Management
+    1.1.1 Project Initiation
+      1.1.1.1 Project Charter Development
+      1.1.1.2 Kickoff Meeting
+    1.1.2 Project Planning
+      1.1.2.1 Develop Project Management Plan
+      1.1.2.2 Create Project Schedule
+    1.1.3 Project Execution
+      1.1.3.1 Status Reporting
+      1.1.3.2 Team Management
+    1.1.4 Project Monitoring and Control
+      1.1.4.1 Change Control
+      1.1.4.2 Risk Management
+    1.1.5 Project Closure
+      1.1.5.1 Final Acceptance
+      1.1.5.2 Lessons Learned
+  1.2 Requirements and Analysis
+    1.2.1 Business Requirements
+      1.2.1.1 Stakeholder Interviews
+      1.2.1.2 Requirements Documentation
+    1.2.2 System Analysis
+      1.2.2.1 Current System Assessment
+      1.2.2.2 Gap Analysis
+    1.2.3 Requirements Approval
+      1.2.3.1 Requirements Review Meeting
+      1.2.3.2 Requirements Sign-off
+  1.3 Solution Design
+    1.3.1 System Architecture
+      1.3.1.1 Technical Architecture Design
+      1.3.1.2 Security Design
+    1.3.2 Database Design
+      1.3.2.1 Data Model Development
+      1.3.2.2 Database Schema Creation
+    1.3.3 User Interface Design
+      1.3.3.1 UI Mockups
+      1.3.3.2 UI Design Approval
+  1.4 System Configuration and Development
+    1.4.1 Environment Setup
+      1.4.1.1 Development Environment
+      1.4.1.2 Test Environment
+      1.4.1.3 Production Environment
+    1.4.2 System Configuration
+      1.4.2.1 Base System Setup
+      1.4.2.2 Module Configuration
+    1.4.3 Custom Development
+      1.4.3.1 Custom Module Development
+      1.4.3.2 Integration Development
+    1.4.4 Data Migration
+      1.4.4.1 Data Cleansing
+      1.4.4.2 Migration Scripts Development
+      1.4.4.3 Test Migration Run
+  1.5 Testing
+    1.5.1 Test Planning
+      1.5.1.1 Test Strategy Development
+      1.5.1.2 Test Case Creation
+    1.5.2 Unit Testing
+      1.5.2.1 Module Testing
+      1.5.2.2 Defect Resolution
+    1.5.3 Integration Testing
+      1.5.3.1 End-to-End Process Testing
+      1.5.3.2 Defect Resolution
+    1.5.4 User Acceptance Testing
+      1.5.4.1 UAT Session Facilitation
+      1.5.4.2 UAT Defect Resolution
+      1.5.4.3 UAT Sign-off
+  1.6 Deployment
+    1.6.1 Deployment Planning
+      1.6.1.1 Deployment Strategy
+      1.6.1.2 Rollback Plan
+    1.6.2 Training
+      1.6.2.1 Training Materials Development
+      1.6.2.2 End-user Training
+      1.6.2.3 Admin Training
+    1.6.3 Go-Live Activities
+      1.6.3.1 Final Data Migration
+      1.6.3.2 System Activation
+      1.6.3.3 Go-Live Support
+  1.7 Post-Implementation Support
+    1.7.1 Hypercare Support
+      1.7.1.1 Day 1-30 Support
+      1.7.1.2 Issue Resolution
+    1.7.2 Transition to Operations
+      1.7.2.1 Knowledge Transfer
+      1.7.2.2 Support Documentation
+      1.7.2.3 Transition Sign-off
+```
+
+---
+
+## WBS Dictionary Template
+
+The WBS Dictionary provides detailed information about each component in the WBS. Here's a template for WBS Dictionary entries:
+
+### WBS Dictionary Entry
+
+| Item | Description |
+|------|-------------|
+| **WBS Code:** | [Unique identifier from WBS] |
+| **WBS Element Name:** | [Name of the deliverable or work package] |
+| **WBS Level:** | [1, 2, 3, etc.] |
+| **Description:** | [Detailed description of what this element includes] |
+| **Deliverables:** | [Specific outputs to be produced] |
+| **Acceptance Criteria:** | [Criteria that must be met for approval] |
+| **Assumptions:** | [Factors assumed to be true for planning purposes] |
+| **Constraints:** | [Factors that limit options for this element] |
+| **Dependencies:** | [Elements that must be completed before/after this element] |
+| **Responsible Party:** | [Person or role responsible for delivery] |
+| **Resource Requirements:** | [Labor, materials, equipment, etc. needed] |
+| **Estimated Duration:** | [Expected time to complete] |
+| **Estimated Effort:** | [Person-hours required] |
+| **Estimated Cost:** | [Budget allocation for this element] |
+| **Quality Requirements:** | [Quality standards that must be met] |
+| **Risks:** | [Known risks associated with this element] |
+| **References:** | [Links to relevant documentation] |
+
+### WBS Dictionary Example Entry
+
+| Item | Description |
+|------|-------------|
+| **WBS Code:** | *1.4.3.1* |
+| **WBS Element Name:** | *Custom Module Development* |
+| **WBS Level:** | *4* |
+| **Description:** | *Design, development, and unit testing of custom modules needed to support specific business requirements not available in the base CRM system.* |
+| **Deliverables:** | *Functional custom modules, Unit test results, Technical documentation* |
+| **Acceptance Criteria:** | *- All modules pass unit tests<br>- Code review completed<br>- Documentation complete and reviewed<br>- Performance meets specified requirements* |
+| **Assumptions:** | *- Development team has required CRM platform expertise<br>- Development environments are available and configured* |
+| **Constraints:** | *- Must use approved development standards<br>- Must maintain compatibility with future system upgrades<br>- Must be completed within 4 weeks* |
+| **Dependencies:** | *- Requires completed System Architecture (1.3.1)<br>- Must be completed before Integration Testing (1.5.3)* |
+| **Responsible Party:** | *Development Team Lead* |
+| **Resource Requirements:** | *2 Senior Developers, 1 Junior Developer, Development environment access* |
+| **Estimated Duration:** | *20 business days* |
+| **Estimated Effort:** | *480 person-hours* |
+| **Estimated Cost:** | *$72,000* |
+| **Quality Requirements:** | *- Code coverage minimum 85%<br>- No critical or high security vulnerabilities<br>- Performance meets SLA requirements* |
+| **Risks:** | *- Limited expertise with certain CRM APIs<br>- Integration complexity may exceed estimates* |
+| **References:** | *- Functional Requirements Doc #FR-123<br>- Technical Design Doc #TD-456* |
+
+---
+
+## Integration with Other Project Documents
+
+The WBS integrates with other project planning documents as follows:
+
+| Document | Integration Point |
+|----------|-------------------|
+| **Project Scope Statement** | The WBS breaks down the approved scope into manageable components |
+| **Project Schedule** | Activities are developed based on WBS work packages |
+| **Resource Assignment Matrix** | WBS work packages are assigned to team members or roles |
+| **Cost Estimates** | Costs are estimated at the work package level and rolled up |
+| **Risk Register** | Risks can be identified and managed at the work package level |
+| **Quality Management Plan** | Quality requirements are defined for WBS components |
+| **Communications Plan** | WBS provides structure for reporting progress |
+| **Procurement Plan** | Identifies components that may require external procurement |
+| **Change Management Plan** | Changes are assessed against the WBS to determine impact |
+
+---
+
+## WBS Development Best Practices
+
+1. **Follow the 100% Rule**
+   - The WBS must include 100% of the work defined in the project scope
+   - The sum of work at each level must equal 100% of the work at the level above
+   - Avoid overlapping work between WBS elements to prevent double-counting
+
+2. **Use Nouns for Deliverables**
+   - Name WBS elements with nouns rather than verbs to emphasize deliverables
+   - Example: Use "Requirements Document" instead of "Document Requirements"
+
+3. **Apply the 8/80 Rule for Work Packages**
+   - Work packages should require more than 8 hours but fewer than 80 hours of effort
+   - This provides a balance between too much detail and not enough control
+
+4. **Keep WBS Levels Consistent**
+   - Maintain consistent detail level across similar components
+   - Avoid over-
+

--- a/REORGANIZATION_PLAN.md
+++ b/REORGANIZATION_PLAN.md
@@ -128,7 +128,7 @@ pm-tools-templates/
 │
 ├── 🏢 business-stakeholder-suite/        # Executive & business tools
 │   ├── executive-dashboards/
-│   │   ├── powerpoint-templates/
+│   │   ├── PowerPoint/
 │   │   ├── excel-workbooks/
 │   │   ├── executive-reports/
 │   │   └── board-presentations/

--- a/business-stakeholder-suite/README.md
+++ b/business-stakeholder-suite/README.md
@@ -30,7 +30,7 @@ These tools work regardless of project methodology:
 **Purpose:** Real-time visibility into project status, risks, and financial performance
 
 **What's Included:**
-- **[PowerPoint Templates](executive-dashboards/powerpoint-templates/)** - Executive presentation slides
+- **[PowerPoint Templates](executive-dashboards/PowerPoint/)** - Executive presentation slides
 - **[Excel Workbooks](executive-dashboards/excel-workbooks/)** - Interactive financial dashboards
 - **[Executive Reports](executive-dashboards/executive-reports/)** - Formal status documentation
 - **[Board Presentations](executive-dashboards/board-presentations/)** - Quarterly governance updates
@@ -88,7 +88,7 @@ These tools work regardless of project methodology:
 - Key decisions required and timing
 
 **Recommended Tools:**
-- [PowerPoint Executive Dashboard](executive-dashboards/powerpoint-templates/) (weekly)
+- [PowerPoint Executive Dashboard](executive-dashboards/PowerPoint/) (weekly)
 - [Executive Status Reports](executive-dashboards/executive-reports/) (monthly)
 - [Email Automation](communication-automation/email-templates/) (ongoing)
 
@@ -189,7 +189,7 @@ These tools work regardless of project methodology:
 
 **Tools to Use:**
 1. **[Business Case Management](strategic-alignment/business-case-management/)** - Document investment justification
-2. **[Executive Dashboard](executive-dashboards/powerpoint-templates/)** - Set up weekly status reporting
+2. **[Executive Dashboard](executive-dashboards/PowerPoint/)** - Set up weekly status reporting
 3. **[Budget Tracking](financial-governance/budget-tracking/)** - Monitor financial performance
 4. **[Communication Automation](communication-automation/email-templates/)** - Keep stakeholders informed
 

--- a/docs/getting-started/template-selector.md
+++ b/docs/getting-started/template-selector.md
@@ -388,7 +388,7 @@ This guide helps you identify and download the specific templates you need based
 ### 📊 **Dashboard Suite** (Business Stakeholders)
 | Template | Update Frequency | Audience | Purpose |
 |----------|------------------|----------|----------|
-| **[PowerPoint Executive Dashboard](../../business-stakeholder-suite/executive-dashboards/powerpoint-templates/)** | Weekly/Monthly | C-Suite | High-level status |
+| **[PowerPoint Executive Dashboard](../../business-stakeholder-suite/executive-dashboards/PowerPoint/)** | Weekly/Monthly | C-Suite | High-level status |
 | **[Excel Executive Workbook](../../business-stakeholder-suite/executive-dashboards/excel-workbooks/)** | Real-time | CFO/PMO | Financial tracking |
 | **[Executive Status Report](../../business-stakeholder-suite/executive-dashboards/executive-reports/)** | Monthly | Board/Executives | Formal documentation |
 | **[Board Presentation](../../business-stakeholder-suite/executive-dashboards/board-presentations/)** | Quarterly | Board of Directors | Strategic oversight |


### PR DESCRIPTION
This PR fixes the remaining broken links to powerpoint-templates throughout the repository.

## Fixed Files:
- ✅ business-stakeholder-suite/README.md (3 instances)
- ✅ docs/getting-started/template-selector.md (1 instance)  
- ✅ REORGANIZATION_PLAN.md (1 instance)

## Changes:
All  references now correctly point to  (capitalized directory).

This resolves the 404 error when clicking on:
https://github.com/mirichard/pm-tools-templates/blob/main/business-stakeholder-suite/executive-dashboards/powerpoint-templates

The link now correctly points to the existing PowerPoint directory.