### PR TITLE
Add Gartner-informed tool strategy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # PM Tools Templates - Comprehensive Enhancement Roadmap
 
-**Last Updated:** June 18, 2025  
+**Last Updated:** June 20, 2025
 **Version:** 3.0  
-**Status:** Active Development - 31 Revolutionary Enhancements Planned
+**Status:** Active Development - 35 Revolutionary Enhancements Planned
 
 ---
 
@@ -24,7 +24,7 @@ Transform the pm-tools-templates repository into **the world's most intelligent 
 
 ### 📈 Enhancement Portfolio Summary
 
-**31 Revolutionary Enhancements Across 5 Phases:**
+**35 Revolutionary Enhancements Across 5 Phases:**
 
 🎯 **User Experience Enhancements (7):** Onboarding, Search, Navigation, Examples, Transparency, Analytics, Community Engagement
 
@@ -37,6 +37,7 @@ Transform the pm-tools-templates repository into **the world's most intelligent 
 🧠 **Data Science & ML (7):** Predictive Forecasting, Resource Optimization, Risk Detection, Template Recommendations, Anomaly Detection, Executive Dashboards, Cost Prediction
 
 🌌 **Revolutionary Technologies (7):** Knowledge Graphs, Sentiment Monitoring, Digital Twins, Low-Code Workflows, Autonomous Risk Orchestration, AR/VR Dashboards, Compliance Copilots
+🛠️ **Gartner-Informed Tool Strategy (4):** Magic Quadrant Integrations, Tool Selection Advisor, Cross-Platform Analytics, Implementation Playbooks
 
 ## 🗺️ Strategic Roadmap Overview
 
@@ -1034,6 +1035,26 @@ Publicly maintain a living ROADMAP (e.g., via GitHub Projects or a visual board)
 - 95+ lighthouse performance score
 - Offline functionality for core features
 - 80% mobile user satisfaction
+
+#### 2.8 Gartner-Informed Tool Strategy
+**Timeline:** October 15, 2025 - March 31, 2026
+**Priority:** Medium
+**Effort:** 20 weeks
+
+**Business Justification:**
+Leverage Gartner Magic Quadrant research and leading practices to guide tool integrations, selection, and deployment playbooks.
+
+**Core Features:**
+- **Magic Quadrant Integrations:** Standardized connectors and configuration guides for top-ranked tools
+- **Adaptive Tool Selection Advisor:** AI-driven recommendations mapped to Gartner ratings
+- **Cross-Platform Analytics Hub:** Aggregated usage and benchmarking dashboards
+- **Implementation Playbooks:** Step-by-step adoption guides with success metrics
+
+**Success Criteria:**
+- Integration blueprints published for 5+ Gartner leaders
+- Advisor reduces tool evaluation time by 50%
+- Analytics hub adopted by 75% of integrated users
+- Playbooks rated 90% helpful by pilot teams
 
 ### 📊 Phase 2 Success Metrics
 - ✅ **Intelligence:** AI insights active on 80% of projects - ACHIEVED

--- a/backlog/issue-alignment-summary.md
+++ b/backlog/issue-alignment-summary.md
@@ -9,7 +9,7 @@
 
 **UPDATE:** All epic issues now follow consistent naming format with proper emoji and numbering structure.
 
-All open GitHub issues have been successfully aligned to the 5 strategic themes from our comprehensive roadmap. Each issue now has proper labeling, epic assignment, and user story format where applicable.
+All open GitHub issues have been successfully aligned to the 6 strategic themes from our comprehensive roadmap. Each issue now has proper labeling, epic assignment, and user story format where applicable.
 
 ---
 
@@ -92,6 +92,16 @@ All open GitHub issues have been successfully aligned to the 5 strategic themes 
 - #96 - Immersive AR/VR Project Progress Dashboard
 - #97 - Regulatory & Compliance Copilot
 
+### 🛠 Theme 6: Gartner-Informed Tool Strategy (4 issues)
+**Epic Issues:**
+- #106 - 🛠 EPIC 6: Gartner-Informed Tool Strategy (4 Sub-Epics)
+
+**User Story Issues:**
+- #107 - Magic Quadrant Integrations & Best Practices
+- #108 - Adaptive Tool Selection Advisor
+- #109 - Cross-Platform Analytics Hub
+- #110 - Gartner-Informed Implementation Playbooks
+
 ### 📋 Strategic/Cross-Theme Issues (15 issues)
 **Multi-Theme Strategic Items:**
 - #23 - 🚀 [EPIC] PM Tools Templates Enhancement Roadmap
@@ -110,10 +120,11 @@ All open GitHub issues have been successfully aligned to the 5 strategic themes 
 - `theme-3-blockchain` - Blockchain Innovation (6 issues)
 - `theme-4-business` - Strategic Business Platform (4 issues)
 - `theme-5-revolutionary` - Revolutionary Technologies (8 issues)
+- `theme-6-gartner` - Gartner-Informed Tool Strategy (4 issues)
 
 ### Type Labels:
-- `epic` - 5 theme epic issues
-- `user-story` - 31 user story issues
+ - `epic` - 6 theme epic issues
+ - `user-story` - 35 user story issues
 - `priority-high` - High priority items
 - `strategic` - Strategic roadmap items
 
@@ -121,7 +132,7 @@ All open GitHub issues have been successfully aligned to the 5 strategic themes 
 
 ## 📋 User Story Conversion
 
-**Issues Converted to User Story Format:** 31 issues  
+**Issues Converted to User Story Format:** 35 issues
 **Standard Format Applied:**
 ```
 ## User Story
@@ -196,6 +207,12 @@ Each user story now clearly references its parent epic:
 - **EPIC 5.6 (AR/VR Dashboard):** Issue #96
 - **EPIC 5.7 (Compliance Copilot):** Issue #97
 
+### Theme 6 Epic Relationships:
+- **EPIC 6.1 (Magic Quadrant Integrations):** Issue #107
+- **EPIC 6.2 (Tool Selection Advisor):** Issue #108
+- **EPIC 6.3 (Analytics Hub):** Issue #109
+- **EPIC 6.4 (Implementation Playbooks):** Issue #110
+
 ---
 
 ## 📊 Success Metrics Integration
@@ -232,11 +249,17 @@ Each user story now includes specific, measurable success criteria aligned with 
 - 90% improvement in stakeholder relationship health
 - 95% reduction in manual risk intervention
 
+### Theme 6 Success Targets:
+- Integration blueprints for 5+ Gartner leaders
+- 50% reduction in tool selection time
+- 75% adoption of analytics hub among integrated users
+- 90% positive rating for implementation playbooks
+
 ---
 
 ## 🚀 Sprint Planning Readiness
 
-**Issues Ready for Sprint Planning:** 31 user stories  
+**Issues Ready for Sprint Planning:** 35 user stories
 **Story Points Assigned:** All stories have Fibonacci estimates (1, 2, 3, 5, 8, 13, 21)  
 **Priority Classification:** Must Have, Should Have, Could Have system applied  
 **Team Assignment Ready:** All issues align with team structure in team-assignments.md  
@@ -268,7 +291,7 @@ Each user story now includes specific, measurable success criteria aligned with 
 - Unclear sprint planning readiness
 
 **After Alignment:**
-- 100% of issues mapped to 5 strategic themes
+ - 100% of issues mapped to 6 strategic themes
 - Clear epic-to-story relationships established
 - Consistent user story format with acceptance criteria
 - Ready for immediate agile development execution
@@ -276,5 +299,5 @@ Each user story now includes specific, measurable success criteria aligned with 
 
 ---
 
-*This alignment ensures that every GitHub issue contributes directly to the 31 revolutionary enhancements outlined in our comprehensive roadmap, enabling systematic execution of the 2025-2027 transformation journey.*
+*This alignment ensures that every GitHub issue contributes directly to the 35 revolutionary enhancements outlined in our comprehensive roadmap, enabling systematic execution of the 2025-2027 transformation journey.*
 

--- a/backlog/roadmap-product-backlog.md
+++ b/backlog/roadmap-product-backlog.md
@@ -1,20 +1,20 @@
 # PM Tools Templates - Roadmap Product Backlog
 
-**Last Updated:** June 18, 2025  
+**Last Updated:** June 20, 2025
 **Version:** 1.0  
-**Status:** Active Development - 31 Revolutionary Enhancements  
+**Status:** Active Development - 35 Revolutionary Enhancements
 
 ---
 
 ## 🎯 Product Vision
 
-Transform the pm-tools-templates repository into **the world's most intelligent project management ecosystem** through 31 revolutionary enhancements across 5 strategic phases, combining proven templates with cutting-edge AI, blockchain, and next-generation technologies.
+Transform the pm-tools-templates repository into **the world's most intelligent project management ecosystem** through 35 revolutionary enhancements across 5 strategic phases, combining proven templates with cutting-edge AI, blockchain, and next-generation technologies.
 
 ---
 
 ## 📊 Roadmap Overview
 
-### 31 Revolutionary Enhancements Across 5 Strategic Themes:
+### 35 Revolutionary Enhancements Across 6 Strategic Themes:
 
 | Theme | Enhancements | Timeline | Priority |
 |-------|-------------|----------|----------|
@@ -23,6 +23,7 @@ Transform the pm-tools-templates repository into **the world's most intelligent 
 | 🌐 **Blockchain Innovation** | 5 Epics | Q4 2025-Q4 2026 | Medium |
 | 💼 **Strategic Business Platform** | 3 Epics | Q1-Q4 2026 | High |
 | 🌌 **Revolutionary Technologies** | 7 Epics | Q1-Q4 2027 | Medium |
+| 🛠️ **Gartner-Informed Tool Strategy** | 4 Epics | Q4 2025-Q4 2026 | Medium |
 
 ---
 
@@ -511,6 +512,61 @@ Transform the pm-tools-templates repository into **the world's most intelligent 
 
 ---
 
+## 🛠 THEME 6: Gartner-Informed Tool Strategy
+
+### EPIC 6.1: Gartner Magic Quadrant Integrations and Best Practices
+**Business Value:** Accelerate adoption of industry-leading tools with standardized integrations and configuration guides
+**Timeline:** Q4 2025 - Q2 2026
+**Status:** Planning
+
+#### User Stories:
+
+| ID | User Story | Acceptance Criteria | Story Points | Priority |
+|----|------------|---------------------|--------------|----------|
+| GT-601 | As an integration architect, I want blueprints for connecting to Gartner Magic Quadrant leaders so that integrations follow best practices | - Reference architectures for Planview, Smartsheet, ServiceNow<br>- Sample configurations and security guidelines<br>- Tested connector templates<br>- Documentation repository | 13 | Must Have |
+| GT-602 | As a PMO lead, I want standardized configuration guides so that teams consistently implement top tools | - Detailed setup checklists<br>- Field mapping recommendations<br>- Workflow configuration examples<br>- Governance considerations | 8 | Must Have |
+| GT-603 | As an analyst, I want comparison matrices of leading tools so that tool selection decisions are evidence-based | - Capability comparison matrix<br>- Exportable evaluation template<br>- Weighted scoring model<br>- Decision log format | 8 | Should Have |
+
+### EPIC 6.2: Adaptive Tool Selection Advisor
+**Business Value:** Reduce tool evaluation time by 50% through AI-driven recommendations
+**Timeline:** Q1-Q2 2026
+**Status:** Concept
+
+#### User Stories:
+
+| ID | User Story | Acceptance Criteria | Story Points | Priority |
+|----|------------|---------------------|--------------|----------|
+| GT-701 | As a portfolio manager, I want an AI advisor that maps project requirements to Gartner data so that I choose the optimal tool | - Project attribute intake form<br>- Gartner data cross-reference<br>- Ranked tool list with rationale<br>- Exportable recommendation | 21 | Must Have |
+| GT-702 | As a team lead, I want to weight deployment preferences so that recommendations align with our infrastructure | - Cloud vs on-prem factors<br>- Integration capability scoring<br>- Scalability assessment<br>- Configurable weighting | 13 | Should Have |
+| GT-703 | As an administrator, I want regular Gartner data updates so that the advisor stays current | - Automated data refresh<br>- Change logs<br>- Versioned recommendation models<br>- Notification of data updates | 8 | Should Have |
+
+### EPIC 6.3: Cross-Platform Analytics Hub
+**Business Value:** Provide unified insights across multiple PM tools
+**Timeline:** Q2-Q3 2026
+**Status:** Concept
+
+#### User Stories:
+
+| ID | User Story | Acceptance Criteria | Story Points | Priority |
+|----|------------|---------------------|--------------|----------|
+| GT-801 | As an executive, I want aggregated dashboards from integrated tools so that I can view portfolio health in one place | - Unified KPI dashboard<br>- Drill-down by tool<br>- PDF/CSV export<br>- Role-based access controls | 21 | Must Have |
+| GT-802 | As a PMO analyst, I want benchmarking data across projects using Gartner leaders so that we can identify best practices | - Data normalization engine<br>- Benchmarking metrics<br>- Automated trend analysis<br>- Peer comparison charts | 13 | Should Have |
+| GT-803 | As a manager, I want predictive analytics that highlight tool optimizations so that teams leverage advanced features | - Usage prediction models<br>- Feature adoption reports<br>- Recommendation engine<br>- Actionable alerts | 13 | Could Have |
+
+### EPIC 6.4: Gartner-Informed Implementation Playbooks
+**Business Value:** Ensure successful deployments of Gartner-ranked tools with consistent practices
+**Timeline:** Q3-Q4 2026
+**Status:** Planning
+
+#### User Stories:
+
+| ID | User Story | Acceptance Criteria | Story Points | Priority |
+|----|------------|---------------------|--------------|----------|
+| GT-901 | As an implementation consultant, I want detailed playbooks so that deployments follow proven methods | - Step-by-step plan templates<br>- Change management guidance<br>- Training materials<br>- Success metrics checklist | 21 | Must Have |
+| GT-902 | As a project manager, I want metrics to measure adoption success so that I can track value realization | - Adoption KPI dashboard<br>- Engagement metrics<br>- Progress report template<br>- Post-implementation survey | 13 | Should Have |
+| GT-903 | As a trainer, I want workshop materials for each tool so that teams ramp up quickly | - Workshop agendas<br>- Sample slides and exercises<br>- Customizable content<br>- Certification path guidance | 8 | Could Have |
+
+
 ## 📊 Success Metrics & KPIs
 
 ### Overall Roadmap Success Metrics
@@ -638,7 +694,7 @@ Transform the pm-tools-templates repository into **the world's most intelligent 
 
 ---
 
-*This roadmap product backlog represents a comprehensive breakdown of all 31 revolutionary enhancements into actionable development items. Each epic and user story is designed to deliver measurable business value while contributing to the overall vision of creating the world's most intelligent project management ecosystem.*
+*This roadmap product backlog represents a comprehensive breakdown of all 35 revolutionary enhancements into actionable development items. Each epic and user story is designed to deliver measurable business value while contributing to the overall vision of creating the world's most intelligent project management ecosystem.*
 
 **For questions, updates, or contributions to this backlog, please engage through GitHub Discussions or create issues in the repository.**
 


### PR DESCRIPTION
## Summary
- update ROADMAP to include a new Gartner-informed tool strategy theme and deliverable
- extend product backlog with Theme 6 and detailed epics & stories
- align issues log with new theme and updated counts

## Testing
- `node tests/test-runner.js`

------
https://chatgpt.com/codex/tasks/task_e_68605ce4d430832a9abafbb7c4606798