### PR TITLE
Add dashboard demo startup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ See the [Template Index](TEMPLATE_INDEX.md) for a full alphabetical list of temp
 ### 📊 Executive Communication?
 <a id="core-template-collections"></a>
 **[💼 Business Stakeholder Suite](business-stakeholder-suite/README.md)** - Professional dashboards and reports
+**[Dashboard MVP Demo](docs/dashboard-mvp-demo.md)** - Run the interactive project health dashboard (`npm run dashboard-demo`)
 <a id="traditionaltraditional-templates"></a>
 
 ## Getting Started

--- a/docs/dashboard-mvp-demo.md
+++ b/docs/dashboard-mvp-demo.md
@@ -1,0 +1,41 @@
+# Dashboard MVP Demo
+
+**Experience the interactive project health dashboard**
+
+The `dashboard-mvp` project provides a production-ready Next.js dashboard for monitoring KPIs, risks, and team performance. Use this demo to explore its features locally.
+
+## 🎯 Features
+- Real-time KPI and risk visualization
+- Customizable widgets and themes
+- Mobile-friendly responsive layout
+
+## 🚀 Running the Demo
+
+### Prerequisites
+- Node.js 18+
+- npm or yarn
+
+### Steps
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/mirichard/pm-tools-templates.git
+   cd pm-tools-templates
+   ```
+2. **Start the demo** using the provided script or npm command
+   ```bash
+   npm run dashboard-demo
+   # or
+   ./scripts/start-dashboard-demo.sh
+   ```
+   The script automatically installs dependencies on first run and creates `.env.local` if needed.
+   Visit [http://localhost:3000](http://localhost:3000) to view the dashboard.
+
+### Production build
+Run these commands inside the `dashboard-mvp` folder:
+```bash
+cd dashboard-mvp
+npm run build
+npm start
+```
+
+For more details see [dashboard-mvp/README.md](../dashboard-mvp/README.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,7 @@ This library provides proven templates, tools, and guidance for project managers
 - **[Repository Status](../REPOSITORY_STATUS.md)**
 - **[Navigation Guide](../NAVIGATION_GUIDE.md)**
 - **[Issues Management](issues-management.md)** - Track project progress
+- **[Dashboard MVP Demo](dashboard-mvp-demo.md)** - Interactive project health dashboard (`npm run dashboard-demo`)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "onboard": "node onboarding/interactive-onboarding.js",
     "test": "echo 'Basic test passed' && exit 0",
     "gateway": "node ecosystem-gateway.js",
-    "quick-start": "node onboarding/interactive-onboarding.js"
+    "quick-start": "node onboarding/interactive-onboarding.js",
+    "dashboard-demo": "npm --prefix dashboard-mvp run dev"
   },
   "keywords": [
     "project-management",

--- a/scripts/start-dashboard-demo.sh
+++ b/scripts/start-dashboard-demo.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Start the Dashboard MVP demo from the repository root
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+cd "$ROOT_DIR/dashboard-mvp"
+
+if [ ! -d node_modules ]; then
+  echo "Installing dashboard-mvp dependencies..."
+  npm install
+fi
+
+# Copy environment template if missing
+test -f .env.local || cp .env.example .env.local
+
+npm run dev


### PR DESCRIPTION
## Summary
- add npm script and shell helper for launching the dashboard-mvp
- update Dashboard MVP demo guide to use the helper
- link demo with command in README and docs index

## Testing
- `npm test`
- `npm run lint` *(fails: unused variables & explicit any)*

------
https://chatgpt.com/codex/tasks/task_e_68616f90ee44832aa97767515022e177