### PR TITLE
docs: terminology alignment (PMBOK → Traditional), canonical links, and index deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 2025-08-08
+
+Summary: Terminology alignment and canonical link updates
+
+- Align user-facing terminology from “PMBOK” to “Traditional” across primary documentation.
+  - Updated templates/README.md, templates/hybrid/Hybrid/README.md, industry-specializations/README.md, templates/traditional/Traditional/README.md, methodology-frameworks/README.md, and examples/README.md.
+  - Preserved legal/trademark statements and authoritative standards citations (e.g., PMBOK® section references), and skipped generated site output.
+- Updated README “Most Popular Templates” to use canonical paths under templates/ and role-based-toolkits.
+- Began deduplication of TEMPLATE_INDEX.md by adding a canonicalization note and retargeting duplicate rows to canonical templates paths.
+- Ran repository link checks for README files; no broken links detected.
+
+Notes:
+- Future work will continue consolidating duplicate index entries and normalizing naming conventions.
+- See CONTRIBUTING.md (Terminology and Standards References) for guidance on when to use “Traditional” vs. PMBOK® citations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,14 @@ We organize content around **how PMs actually work**:
 ### 3. Follow Our Principles
 - **Practical over Perfect**: Templates should work in real projects
 - **User-Centric**: Organized by user needs, not theoretical frameworks
-- **Methodology-Agnostic**: Core templates work across Agile, Waterfall, and Hybrid
+- **Methodology-Agnostic**: Core templates work across Agile, Waterfall (Traditional), and Hybrid
 - **Immediately Useful**: No extensive setup or learning curve required
+
+### 4. Terminology and Standards References
+- Use “Traditional” as the user-facing term for waterfall/PMBOK-aligned content.
+- Preserve PMBOK® references only when citing official standards, sections, or guidance (e.g., “PMBOK® 5.4.2.1”).
+- Do not alter legal/trademark notices that reference PMBOK®.
+- Avoid introducing “PMBOK” in new user-facing copy; prefer “Traditional” unless a standards citation is required.
 
 ## 📝 Template Contribution Guidelines
 
@@ -153,6 +159,13 @@ template-name/
    - Include a filled example (with sensitive data removed)
 
 ### Step 3: Submit Your Pull Request
+
+Before opening a PR, run the local link check to catch broken references:
+
+```bash
+# Quick README link check without external dependencies
+python3 check_links_no_deps.py
+```
 
 1. **Commit Your Changes**
    ```bash

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@
 - [Project Charter Template](templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md) - Start any project
 - [Sprint Planning Template](templates/agile/sprint_planning_template.md) - Plan agile sprints  
 - [Risk Register Template](templates/traditional/Traditional/Templates/risk_register_template.md) - Manage project risks
-- [Status Report Template](project-lifecycle/04-monitoring-control/progress-tracking/status-report-template.md) - Report progress
-- [Stakeholder Register Template](project-lifecycle/01-initiation/stakeholder-analysis/stakeholder-register-template.md) - Manage stakeholders
+- [Status Report Template](templates/traditional/Traditional/Templates/status_report_template.md) - Report progress
+- [Stakeholder Register Template](role-based-toolkits/project-manager/essential-templates/stakeholder-register.md) - Manage stakeholders
 
 ### Popular Tags
 

--- a/TEMPLATE_INDEX.md
+++ b/TEMPLATE_INDEX.md
@@ -21,6 +21,8 @@
 
 ## 📋 All Templates
 
+Note: Each entry links to the canonical template location. Where multiple variants exist, the canonical path is preferred; alternate variants may be listed in the template’s Related section.
+
 | Template | Methodology | Complexity | Updated | Link |
 |----------|-------------|------------|---------|------|
 | Advanced Business Case Template | universal | advanced | 2025-08-05 | [View](business-stakeholder-suite/financial-governance/enhanced-business-cases/advanced-business-case-template.md) |
@@ -89,7 +91,6 @@
 | Installation Qualification Protocol Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/validation/installation_qualification_protocol_template.md) |
 | Integrated Change Strategy Template | hybrid | advanced | 2025-08-05 | [View](templates/hybrid/Hybrid/Templates/integrated_change_strategy_template.md) |
 | Issue Log Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/issue_log_template.md) |
-| Issue Log Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/issue-management/issue-log-template.md) |
 | Less Retrospective Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/less/less_retrospective_template.md) |
 | Less Sprint Planning Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/less/less_sprint_planning_template.md) |
 | Manufacturing Batch Record Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/manufacturing/manufacturing_batch_record_template.md) |
@@ -114,7 +115,6 @@
 | Program Charter Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/program_charter_template.md) |
 | Program Management Plan Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/program_management_plan_template.md) |
 | Progressive Acceptance Plan Template | hybrid | advanced | 2025-08-05 | [View](templates/hybrid/Hybrid/Templates/progressive_acceptance_plan_template.md) |
-| Project Charter Template | Traditional | Not specified | Not specified | [View](templates/traditional/project-charter-template.md) |
 | Project Charter Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md) |
 | Project Closure Report Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Closing/project_closure_report_template.md) |
 | Project Dashboard Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/progress-tracking/project-dashboard-template.md) |
@@ -141,7 +141,6 @@
 | Risk Management Assessment Template | universal | starter | 2025-08-05 | [View](project-assessment-suite/risk-management-assessment-template.md) |
 | Risk Management Plan Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/risk-management/risk-management-plan-template.md) |
 | Risk Register Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/risk_register_template.md) |
-| Risk Register Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/risk-management/risk-register-template.md) |
 | Roi Tracking Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Knowledge_Areas/Project_Cost_Management/roi_tracking_template.md) |
 | Safe Art Coordination Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/safe/safe_art_coordination_template.md) |
 | Safe Metrics Dashboard Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/safe/safe_metrics_dashboard_template.md) |
@@ -151,9 +150,6 @@
 | Skills Matrix Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/resource-planning/skills-matrix-template.md) |
 | Software Requirements Specification Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/validation/software_requirements_specification_template.md) |
 | Sprint Planning Template | agile | intermediate | 2025-08-05 | [View](templates/agile/sprint_planning_template.md) |
-| Sprint Planning Template | Scrum | Not specified | Not specified | [View](templates/agile/sprint-planning-template.md) |
-| Sprint Planning Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-planning-template.md) |
-| Sprint Planning Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/sprint-planning/sprint_planning_template.md) |
 | Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_retrospective_template.md) |
 | Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-retrospective-template.md) |
 | Sprint Review Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_review_template.md) |
@@ -161,14 +157,11 @@
 | Stakeholder Engagement Assessment Template | universal | starter | 2025-08-05 | [View](project-assessment-suite/stakeholder-engagement-assessment-template.md) |
 | Stakeholder Register Template | universal | intermediate | 2025-08-05 | [View](project-lifecycle/01-initiation/stakeholder-analysis/stakeholder-register-template.md) |
 | Status Report Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/status_report_template.md) |
-| Status Report Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/progress-tracking/status-report-template.md) |
 | Team Charter Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/resource-planning/team-charter-template.md) |
 | Team Performance Assessment Template | traditional | intermediate | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Executing/team_performance_assessment_template.md) |
 | Technical Design Document Template | universal | advanced | 2025-08-05 | [View](industry-specializations/information-technology/software-development/technical_design_document_template.md) |
 | Test Plan Template | universal | advanced | 2025-08-05 | [View](industry-specializations/information-technology/software-development/test_plan_template.md) |
 | Timesheet Tracking Template | universal | intermediate | 2025-08-05 | [View](role-based-toolkits/project-manager/essential-templates/timesheet-tracking-template.md) |
-| Traditional Project Charter Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/01-initiation/project-charter/traditional-project-charter-template.md) |
-| Traditional Project Management Plan Template | universal | intermediate | 2025-08-05 | [View](project-lifecycle/02-planning/project-management-plan/traditional-project-management-plan-template.md) |
 | Uat Plan Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/uat_plan_template.md) |
 | Uat Strategy Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/uat_strategy_template.md) |
 | User Empathy Mapping Template | universal | advanced | 2025-08-05 | [View](methodology-frameworks/emerging-methods/design-thinking/user_empathy_mapping_template.md) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ examples/
 
 ---
 
-### **Healthcare Implementation - Traditional PMBOK**
+### **Healthcare Implementation - Traditional**
 **Project:** Electronic Health Records (EHR) System Implementation  
 **Industry:** Healthcare/Hospital Network  
 **Duration:** 24 months  
@@ -109,7 +109,7 @@ examples/
 - Integrate with 50+ existing healthcare systems
 
 **Methodology Applied:**
-- **Traditional PMBOK** - Structured phase-gate approach
+- **Traditional** - Structured phase-gate approach
 - **Risk-Heavy Planning** - Extensive risk management due to patient safety
 - **Vendor Management** - Complex multi-vendor coordination
 

--- a/industry-specializations/README.md
+++ b/industry-specializations/README.md
@@ -222,7 +222,7 @@ Implement: Industry frameworks → Proven approaches for your sector's unique ch
 ## 🔗 **Related Resources**
 
 ### **Within This Repository:**
-- [`/Traditional/`](../Traditional/) - PMBOK framework with industry adaptations
+- [`/Traditional/`](../Traditional/) - Traditional framework with industry adaptations
 - [`/Agile/`](../Agile/) - Agile practices for industry-specific contexts
 - [`/Hybrid/`](../Hybrid/) - Hybrid approaches for complex industry requirements
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific tools across industries

--- a/methodology-frameworks/README.md
+++ b/methodology-frameworks/README.md
@@ -21,7 +21,7 @@
 ```
 methodology-frameworks/
 ├── Agile-Scrum/
-├── Traditional-PMBOK/
+├──  ̿Traditional/
 ├── Hybrid/
 └── Comparisons/
 ```
@@ -29,7 +29,7 @@ methodology-frameworks/
 ### Sections:
 
 - **Agile-Scrum**: Comprehensive guides to the Agile methodology focusing on Scrum practices and roles.
-- **Traditional-PMBOK**: In-depth exploration of the PMBOK approach, project phases, and traditional methodologies.
+- **Traditional**: In-depth exploration of traditional approaches, project phases, and related standards.
 - **Hybrid**: Exploration of how to effectively blend Agile and Traditional practices.
 - **Comparisons**: Side-by-side analysis of different methodologies to aid in decision making.
 
@@ -44,8 +44,8 @@ methodology-frameworks/
   - Strategies for effective scrum ceremonies and backlog management
   - Best practices for agile scaling (e.g., SAFe, LeSS)
 
-- **Traditional-PMBOK**:
-  - Exploration of the 10 PMBOK knowledge areas
+- **Traditional**:
+  - Exploration of traditional knowledge areas and practices
   - Phase-specific guidance (Initiating, Planning, Executing, Monitoring & Controlling, Closing)
   - Quality assurance, risk management, and change control processes
 
@@ -77,12 +77,12 @@ methodology-frameworks/
 
 ### Within This Repository:
 - `/Agile/`: Templates, tools, and practices for Agile methodologies
-- `/Traditional/`: Templates and best practices aligned with PMBOK
+- `/Traditional/`: Templates and best practices aligned with Traditional methodologies
 - `/Hybrid/`: Adaptive strategies for combining different methodologies
 
 ### External References:
 - [Scrum Alliance](https://scrumalliance.org/): Certification and resources for Scrum practitioners
-- [PMI](https://pmi.org/): Resources for PMBOK and professional certification
+- [PMI](https://pmi.org/): Resources for standards and professional certification
 - [Scaled Agile](https://scaledagileframework.com/): Framework for scaling agile across the enterprise
 
 ---

--- a/templates/README.md
+++ b/templates/README.md
@@ -23,7 +23,7 @@ This is your central template repository containing the most frequently used and
 templates/
 ├── agile/              # Agile-specific template variations
 ├── hybrid/             # Hybrid methodology templates
-├── traditional/        # Traditional/PMBOK template variations
+├── traditional/        # Traditional template variations
 └── test-samples/       # Example implementations and demos
 ```
 
@@ -43,7 +43,7 @@ Begin with: **Project Initiation Templates** → Charter, stakeholder analysis, 
 
 ### **2. Know Your Methodology?**
 - **Agile Projects:** → `agile/` directory for sprint-based templates
-- **Traditional Projects:** → `traditional/` directory for PMBOK-aligned templates  
+- **Traditional Projects:** → `traditional/` directory for Traditional-aligned templates  
 - **Mixed Approach:** → `hybrid/` directory for combined methodology templates
 
 ### **3. Need Specific Template Type?**
@@ -213,7 +213,7 @@ Check: `test-samples/` → Real-world template applications and case studies
 
 ### **Within This Repository:**
 - [`/Agile/`](../Agile/) - Complete agile methodology toolkit
-- [`/Traditional/`](../Traditional/) - Full PMBOK-aligned resources
+- [`/Traditional/`](../Traditional/) - Full Traditional-aligned resources
 - [`/Hybrid/`](../Hybrid/) - Hybrid methodology frameworks
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific template collections
 - [`/industry-specializations/`](../industry-specializations/) - Industry-adapted templates

--- a/templates/hybrid/Hybrid/README.md
+++ b/templates/hybrid/Hybrid/README.md
@@ -1,6 +1,6 @@
 # Hybrid Project Management Templates & Tools
 
-> **Best of Both Worlds** - Intelligently combine Traditional (PMBOK) structure with Agile flexibility for optimal project outcomes across diverse organizational contexts.
+> **Best of Both Worlds** - Intelligently combine Traditional structure with Agile flexibility for optimal project outcomes across diverse organizational contexts.
 
 ---
 
@@ -57,7 +57,7 @@ Check: `Tools/` → Methodology selection and maturity assessment tools
 
 ### **🏗️ Traditional Planning → Agile Execution**
 **Best For:** Large programs, fixed budgets, regulatory requirements
-- **Phase 1:** Traditional initiation and detailed planning (PMBOK)
+- **Phase 1:** Traditional initiation and detailed planning
 - **Phase 2:** Agile execution with sprints and iterations
 - **Phase 3:** Traditional closure and governance reporting
 
@@ -276,7 +276,7 @@ Located in: `MPP-Jira-Integration/`
 
 ### **Within This Repository:**
 - [`/Agile/`](../Agile/) - Pure agile methodology templates and tools
-- [`/Traditional/`](../Traditional/) - PMBOK-aligned traditional project management
+- [`/Traditional/`](../Traditional/) - Traditional-aligned project management
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific hybrid tools
 - [`/methodology-frameworks/`](../methodology-frameworks/) - Comparative methodology guidance
 

--- a/templates/traditional/Traditional/README.md
+++ b/templates/traditional/Traditional/README.md
@@ -1,6 +1,6 @@
 # Traditional Project Management Templates & Tools
 
-> **PMBOK-Aligned Excellence** - Comprehensive templates and tools based on PMI standards, waterfall methodology, and traditional project management best practices.
+> **Traditional-Aligned Excellence** - Comprehensive templates and tools based on PMI standards, waterfall methodology, and traditional project management best practices.
 
 ---
 
@@ -169,7 +169,7 @@ Explore: `Templates/program-management/` → Multi-project coordination tools
 
 ---
 
-## 🎓 **PMBOK Alignment & Best Practices**
+## 🎓 **Traditional Alignment & Best Practices**
 
 ### **PMI Standards Integration**
 - **PMBOK Guide 7th Edition** - Process-based and principles-based approaches
@@ -293,5 +293,5 @@ Explore: `Templates/program-management/` → Multi-project coordination tools
 
 **Last Updated:** August 2025  
 **Maintained By:** PM Tools Templates Community  
-**PMBOK Version:** 7th Edition Aligned  
+**Standards Alignment:** PMBOK® 7th Edition  
 **Certification:** PMP®-Aligned Templates


### PR DESCRIPTION
Summary\n- Align user-facing terminology from PMBOK to Traditional across primary docs\n- Preserve PMBOK® only for standards citations and legal notices\n- Update README ‘Most Popular’ links to canonical templates\n- Add terminology guidance and local link-check step to CONTRIBUTING.md\n- Add CHANGELOG.md entry\n- Deduplicate TEMPLATE_INDEX.md entries and add canonicalization note\n\nScope and safety\n- Excludes legal/trademark notices and scripts that inject legal text\n- Excludes generated site output (docs/site/dist and docs/site/public)\n- Preserves explicit PMBOK® section citations (e.g., 5.4.2.1)\n\nValidation\n- Ran local README link checker (check_links_no_deps.py): 0 broken links\n\nNext steps\n- Continue collapsing remaining duplicate index entries as needed\n- Optionally add stubs in red-zone directories pointing users to templates/ and Navigation Guide\n\nCloses: n/a