### PR TITLE
chore: prefer canonical_path in index generator and selector CLI

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,24 @@
+name: Docs Link Check
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - '.github/workflows/docs-link-check.yml'
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run local README link checker
+        run: |
+          python3 check_links_no_deps.py || true
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 2025-08-08
+
+Summary: Terminology alignment and canonical link updates
+
+- Align user-facing terminology from “PMBOK” to “Traditional” across primary documentation.
+  - Updated templates/README.md, templates/hybrid/Hybrid/README.md, industry-specializations/README.md, templates/traditional/Traditional/README.md, methodology-frameworks/README.md, and examples/README.md.
+  - Preserved legal/trademark statements and authoritative standards citations (e.g., PMBOK® section references), and skipped generated site output.
+- Updated README “Most Popular Templates” to use canonical paths under templates/ and role-based-toolkits.
+- Began deduplication of TEMPLATE_INDEX.md by adding a canonicalization note and retargeting duplicate rows to canonical templates paths.
+- Ran repository link checks for README files; no broken links detected.
+
+Notes:
+- Future work will continue consolidating duplicate index entries and normalizing naming conventions.
+- See CONTRIBUTING.md (Terminology and Standards References) for guidance on when to use “Traditional” vs. PMBOK® citations.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,14 @@ We organize content around **how PMs actually work**:
 ### 3. Follow Our Principles
 - **Practical over Perfect**: Templates should work in real projects
 - **User-Centric**: Organized by user needs, not theoretical frameworks
-- **Methodology-Agnostic**: Core templates work across Agile, Waterfall, and Hybrid
+- **Methodology-Agnostic**: Core templates work across Agile, Waterfall (Traditional), and Hybrid
 - **Immediately Useful**: No extensive setup or learning curve required
+
+### 4. Terminology and Standards References
+- Use “Traditional” as the user-facing term for waterfall/PMBOK-aligned content.
+- Preserve PMBOK® references only when citing official standards, sections, or guidance (e.g., “PMBOK® 5.4.2.1”).
+- Do not alter legal/trademark notices that reference PMBOK®.
+- Avoid introducing “PMBOK” in new user-facing copy; prefer “Traditional” unless a standards citation is required.
 
 ## 📝 Template Contribution Guidelines
 
@@ -153,6 +159,13 @@ template-name/
    - Include a filled example (with sensitive data removed)
 
 ### Step 3: Submit Your Pull Request
+
+Before opening a PR, run the local link check to catch broken references:
+
+```bash
+# Quick README link check without external dependencies
+python3 check_links_no_deps.py
+```
 
 1. **Commit Your Changes**
    ```bash

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@
 - [Project Charter Template](templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md) - Start any project
 - [Sprint Planning Template](templates/agile/sprint_planning_template.md) - Plan agile sprints  
 - [Risk Register Template](templates/traditional/Traditional/Templates/risk_register_template.md) - Manage project risks
-- [Status Report Template](project-lifecycle/04-monitoring-control/progress-tracking/status-report-template.md) - Report progress
-- [Stakeholder Register Template](project-lifecycle/01-initiation/stakeholder-analysis/stakeholder-register-template.md) - Manage stakeholders
+- [Status Report Template](templates/traditional/Traditional/Templates/status_report_template.md) - Report progress
+- [Stakeholder Register Template](role-based-toolkits/project-manager/essential-templates/stakeholder-register.md) - Manage stakeholders
 
 ### Popular Tags
 

--- a/TEMPLATE_INDEX.md
+++ b/TEMPLATE_INDEX.md
@@ -21,6 +21,8 @@
 
 ## 📋 All Templates
 
+Note: Each entry links to the canonical template location. Where multiple variants exist, the canonical path is preferred; alternate variants may be listed in the template’s Related section.
+
 | Template | Methodology | Complexity | Updated | Link |
 |----------|-------------|------------|---------|------|
 | Advanced Business Case Template | universal | advanced | 2025-08-05 | [View](business-stakeholder-suite/financial-governance/enhanced-business-cases/advanced-business-case-template.md) |
@@ -89,7 +91,6 @@
 | Installation Qualification Protocol Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/validation/installation_qualification_protocol_template.md) |
 | Integrated Change Strategy Template | hybrid | advanced | 2025-08-05 | [View](templates/hybrid/Hybrid/Templates/integrated_change_strategy_template.md) |
 | Issue Log Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/issue_log_template.md) |
-| Issue Log Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/issue-management/issue-log-template.md) |
 | Less Retrospective Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/less/less_retrospective_template.md) |
 | Less Sprint Planning Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/less/less_sprint_planning_template.md) |
 | Manufacturing Batch Record Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/manufacturing/manufacturing_batch_record_template.md) |
@@ -114,7 +115,6 @@
 | Program Charter Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/program_charter_template.md) |
 | Program Management Plan Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/program_management_plan_template.md) |
 | Progressive Acceptance Plan Template | hybrid | advanced | 2025-08-05 | [View](templates/hybrid/Hybrid/Templates/progressive_acceptance_plan_template.md) |
-| Project Charter Template | Traditional | Not specified | Not specified | [View](templates/traditional/project-charter-template.md) |
 | Project Charter Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md) |
 | Project Closure Report Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Closing/project_closure_report_template.md) |
 | Project Dashboard Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/progress-tracking/project-dashboard-template.md) |
@@ -141,7 +141,6 @@
 | Risk Management Assessment Template | universal | starter | 2025-08-05 | [View](project-assessment-suite/risk-management-assessment-template.md) |
 | Risk Management Plan Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/risk-management/risk-management-plan-template.md) |
 | Risk Register Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/risk_register_template.md) |
-| Risk Register Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/risk-management/risk-register-template.md) |
 | Roi Tracking Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Knowledge_Areas/Project_Cost_Management/roi_tracking_template.md) |
 | Safe Art Coordination Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/safe/safe_art_coordination_template.md) |
 | Safe Metrics Dashboard Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/scaling-frameworks/safe/safe_metrics_dashboard_template.md) |
@@ -151,9 +150,6 @@
 | Skills Matrix Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/resource-planning/skills-matrix-template.md) |
 | Software Requirements Specification Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/validation/software_requirements_specification_template.md) |
 | Sprint Planning Template | agile | intermediate | 2025-08-05 | [View](templates/agile/sprint_planning_template.md) |
-| Sprint Planning Template | Scrum | Not specified | Not specified | [View](templates/agile/sprint-planning-template.md) |
-| Sprint Planning Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-planning-template.md) |
-| Sprint Planning Template | agile | advanced | 2025-08-05 | [View](methodology-frameworks/agile-scrum/sprint-planning/sprint_planning_template.md) |
 | Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_retrospective_template.md) |
 | Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-retrospective-template.md) |
 | Sprint Review Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_review_template.md) |
@@ -161,14 +157,11 @@
 | Stakeholder Engagement Assessment Template | universal | starter | 2025-08-05 | [View](project-assessment-suite/stakeholder-engagement-assessment-template.md) |
 | Stakeholder Register Template | universal | intermediate | 2025-08-05 | [View](project-lifecycle/01-initiation/stakeholder-analysis/stakeholder-register-template.md) |
 | Status Report Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/status_report_template.md) |
-| Status Report Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/04-monitoring-control/progress-tracking/status-report-template.md) |
 | Team Charter Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/resource-planning/team-charter-template.md) |
 | Team Performance Assessment Template | traditional | intermediate | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Executing/team_performance_assessment_template.md) |
 | Technical Design Document Template | universal | advanced | 2025-08-05 | [View](industry-specializations/information-technology/software-development/technical_design_document_template.md) |
 | Test Plan Template | universal | advanced | 2025-08-05 | [View](industry-specializations/information-technology/software-development/test_plan_template.md) |
 | Timesheet Tracking Template | universal | intermediate | 2025-08-05 | [View](role-based-toolkits/project-manager/essential-templates/timesheet-tracking-template.md) |
-| Traditional Project Charter Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/01-initiation/project-charter/traditional-project-charter-template.md) |
-| Traditional Project Management Plan Template | universal | intermediate | 2025-08-05 | [View](project-lifecycle/02-planning/project-management-plan/traditional-project-management-plan-template.md) |
 | Uat Plan Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/uat_plan_template.md) |
 | Uat Strategy Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/uat_strategy_template.md) |
 | User Empathy Mapping Template | universal | advanced | 2025-08-05 | [View](methodology-frameworks/emerging-methods/design-thinking/user_empathy_mapping_template.md) |

--- a/TEMPLATE_INDEX.md
+++ b/TEMPLATE_INDEX.md
@@ -151,11 +151,9 @@ Note: Each entry links to the canonical template location. Where multiple varian
 | Software Requirements Specification Template | universal | advanced | 2025-08-05 | [View](industry-specializations/healthcare-pharmaceutical/validation/software_requirements_specification_template.md) |
 | Sprint Planning Template | agile | intermediate | 2025-08-05 | [View](templates/agile/sprint_planning_template.md) |
 | Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_retrospective_template.md) |
-| Sprint Retrospective Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-retrospective-template.md) |
 | Sprint Review Template | agile | advanced | 2025-08-05 | [View](templates/agile/sprint_review_template.md) |
-| Sprint Review Template | agile | advanced | 2025-08-05 | [View](role-based-toolkits/scrum-master/agile-ceremonies/sprint-review-template.md) |
 | Stakeholder Engagement Assessment Template | universal | starter | 2025-08-05 | [View](project-assessment-suite/stakeholder-engagement-assessment-template.md) |
-| Stakeholder Register Template | universal | intermediate | 2025-08-05 | [View](project-lifecycle/01-initiation/stakeholder-analysis/stakeholder-register-template.md) |
+| Stakeholder Register Template | universal | intermediate | 2025-08-05 | [View](role-based-toolkits/project-manager/essential-templates/stakeholder-register.md) |
 | Status Report Template | traditional | advanced | 2025-08-05 | [View](templates/traditional/Traditional/Templates/status_report_template.md) |
 | Team Charter Template | universal | advanced | 2025-08-05 | [View](project-lifecycle/02-planning/resource-planning/team-charter-template.md) |
 | Team Performance Assessment Template | traditional | intermediate | 2025-08-05 | [View](templates/traditional/Traditional/Process_Groups/Executing/team_performance_assessment_template.md) |

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,71 @@
+# Template Accessibility Checklist
+
+Purpose: Help authors and users ensure templates are usable by everyone and meet common accessibility expectations in documents and web-rendered Markdown.
+
+Core principles
+- Perceivable: Information and UI components must be presentable to users in ways they can perceive
+- Operable: Users must be able to operate the interface
+- Understandable: Information and operation must be understandable
+- Robust: Content must be interpreted reliably by a wide variety of user agents and assistive technologies
+
+Checklist (apply to Markdown, Word, Excel, PowerPoint, and PDFs as relevant)
+1) Structure and headings
+- Use a single H1 title, followed by hierarchical headings (H2/H3) without skipping levels
+- Use built‑in heading styles (Word/PPT) so screen readers can navigate
+- Avoid using bold text in place of true headings
+
+2) Text alternatives
+- Provide meaningful alt text for images and diagrams
+- If an image is purely decorative, mark it as decorative (empty alt in HTML/MD or appropriate property in Office)
+- Prefer text or data tables over screenshots when feasible
+
+3) Color and contrast
+- Ensure sufficient contrast (target ≥4.5:1 for normal text, ≥3:1 for large text)
+- Do not rely on color alone to convey meaning (add labels, patterns, or text)
+
+4) Links and references
+- Use descriptive link text (e.g., “Status Report Template”) instead of “click here”
+- Prefer relative links within the repo and link to canonical locations
+
+5) Tables and data
+- Add header rows for tables; use simple table structures where possible
+- Include captions or a brief description of table purpose when helpful
+- In Excel, label sheets clearly; freeze header rows; avoid merged cells in data tables
+
+6) Language and readability
+- Write in plain language; avoid unexplained acronyms
+- Keep sentences concise; use lists for steps and checklists
+
+7) Forms and inputs
+- Label required fields and provide examples/placeholders
+- Provide clear instructions for completing the template
+
+8) Multimedia (if applicable)
+- Provide captions or transcripts for embedded audio/video
+- Avoid auto‑play; let the user control playback
+
+9) Keyboard and assistive tech
+- Ensure no interaction requires a mouse exclusively
+- In PowerPoint, follow reading order; in Markdown/HTML, ensure logical DOM order
+
+10) Document properties and export
+- Set document title and language; include author and version where applicable
+- When exporting to PDF, use tagged PDFs to preserve structure
+
+Quick author workflow
+- Author with structure-first approach (true headings, lists, tables)
+- Run an accessibility checker:
+  - Word/PowerPoint: Review > Check Accessibility
+  - PDF: Acrobat Pro > Accessibility Check (if available)
+  - Markdown: Use linters or preview with a screen reader spot-check
+- Address issues and re‑run checks before publishing
+
+References
+- WCAG 2.1 Quick Reference: https://www.w3.org/WAI/WCAG21/quickref/
+- Microsoft Office Accessibility: https://support.microsoft.com/accessibility
+- PDF/UA basics: https://www.pdfa.org/resource/pdfua-in-a-nutshell/
+
+Maintenance note
+- Treat accessibility fixes like quality bugs: track, fix, and prevent regressions
+- Prefer canonical links and consistent naming to reduce wayfinding barriers
+

--- a/docs/getting-started/template-selector.md
+++ b/docs/getting-started/template-selector.md
@@ -22,6 +22,14 @@ estimated_completion_time: "90-120 minutes"
 
 # Interactive Template Selector
 
+Quick CLI usage (optional)
+
+- List templates by filters:
+  - npm run template-selector -- --list --methodology=traditional --search="charter"
+  - npm run template-selector -- --list --tags="risk" --complexity=advanced
+- Copy a template to a destination with optional front-matter injection:
+  - npm run template-selector -- --title="Project Charter Template" --dest=./my-project/docs --inject="project_name=Acme,owner=Jane Doe,date=2025-08-08"
+
 **Find the right templates for your situation in 2 minutes**
 
 ## Quick Selector

--- a/examples/README.md
+++ b/examples/README.md
@@ -96,7 +96,7 @@ examples/
 
 ---
 
-### **Healthcare Implementation - Traditional PMBOK**
+### **Healthcare Implementation - Traditional**
 **Project:** Electronic Health Records (EHR) System Implementation  
 **Industry:** Healthcare/Hospital Network  
 **Duration:** 24 months  
@@ -109,7 +109,7 @@ examples/
 - Integrate with 50+ existing healthcare systems
 
 **Methodology Applied:**
-- **Traditional PMBOK** - Structured phase-gate approach
+- **Traditional** - Structured phase-gate approach
 - **Risk-Heavy Planning** - Extensive risk management due to patient safety
 - **Vendor Management** - Complex multi-vendor coordination
 

--- a/industry-specializations/README.md
+++ b/industry-specializations/README.md
@@ -222,7 +222,7 @@ Implement: Industry frameworks → Proven approaches for your sector's unique ch
 ## 🔗 **Related Resources**
 
 ### **Within This Repository:**
-- [`/Traditional/`](../Traditional/) - PMBOK framework with industry adaptations
+- [`/Traditional/`](../Traditional/) - Traditional framework with industry adaptations
 - [`/Agile/`](../Agile/) - Agile practices for industry-specific contexts
 - [`/Hybrid/`](../Hybrid/) - Hybrid approaches for complex industry requirements
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific tools across industries

--- a/methodology-frameworks/README.md
+++ b/methodology-frameworks/README.md
@@ -21,7 +21,7 @@
 ```
 methodology-frameworks/
 ├── Agile-Scrum/
-├── Traditional-PMBOK/
+├──  ̿Traditional/
 ├── Hybrid/
 └── Comparisons/
 ```
@@ -29,7 +29,7 @@ methodology-frameworks/
 ### Sections:
 
 - **Agile-Scrum**: Comprehensive guides to the Agile methodology focusing on Scrum practices and roles.
-- **Traditional-PMBOK**: In-depth exploration of the PMBOK approach, project phases, and traditional methodologies.
+- **Traditional**: In-depth exploration of traditional approaches, project phases, and related standards.
 - **Hybrid**: Exploration of how to effectively blend Agile and Traditional practices.
 - **Comparisons**: Side-by-side analysis of different methodologies to aid in decision making.
 
@@ -44,8 +44,8 @@ methodology-frameworks/
   - Strategies for effective scrum ceremonies and backlog management
   - Best practices for agile scaling (e.g., SAFe, LeSS)
 
-- **Traditional-PMBOK**:
-  - Exploration of the 10 PMBOK knowledge areas
+- **Traditional**:
+  - Exploration of traditional knowledge areas and practices
   - Phase-specific guidance (Initiating, Planning, Executing, Monitoring & Controlling, Closing)
   - Quality assurance, risk management, and change control processes
 
@@ -77,12 +77,12 @@ methodology-frameworks/
 
 ### Within This Repository:
 - `/Agile/`: Templates, tools, and practices for Agile methodologies
-- `/Traditional/`: Templates and best practices aligned with PMBOK
+- `/Traditional/`: Templates and best practices aligned with Traditional methodologies
 - `/Hybrid/`: Adaptive strategies for combining different methodologies
 
 ### External References:
 - [Scrum Alliance](https://scrumalliance.org/): Certification and resources for Scrum practitioners
-- [PMI](https://pmi.org/): Resources for PMBOK and professional certification
+- [PMI](https://pmi.org/): Resources for standards and professional certification
 - [Scaled Agile](https://scaledagileframework.com/): Framework for scaling agile across the enterprise
 
 ---

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build-site": "npm run generate-changelogs && npm --prefix docs/site run build",
     "dev-site": "npm --prefix docs/site run dev",
     "preview-site": "npm --prefix docs/site run preview",
-    "doc-scan": "node scripts/doc-scan.js"
+    "doc-scan": "node scripts/doc-scan.js",
+    "template-selector": "node scripts/template-selector.mjs"
   },
   "keywords": [
     "project-management",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "quick-start": "node onboarding/interactive-onboarding.js",
     "dashboard-demo": "npm --prefix dashboard-mvp run dev",
     "generate-changelogs": "node scripts/generate-changelogs.mjs",
-    "build-site": "npm run generate-changelogs && npm --prefix docs/site run build",
+    "generate-template-index": "node scripts/generate_template_index.mjs",
+    "build-site": "npm run generate-changelogs && npm --prefix docs/site run build",
     "dev-site": "npm --prefix docs/site run dev",
     "preview-site": "npm --prefix docs/site run preview",
     "doc-scan": "node scripts/doc-scan.js"

--- a/project-lifecycle/01-initiation/business-case/README.md
+++ b/project-lifecycle/01-initiation/business-case/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/01-initiation/feasibility-study/README.md
+++ b/project-lifecycle/01-initiation/feasibility-study/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/02-planning/communication-planning/README.md
+++ b/project-lifecycle/02-planning/communication-planning/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/02-planning/schedule-planning/README.md
+++ b/project-lifecycle/02-planning/schedule-planning/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/02-planning/scope-management/README.md
+++ b/project-lifecycle/02-planning/scope-management/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/03-execution/quality-assurance/README.md
+++ b/project-lifecycle/03-execution/quality-assurance/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/03-execution/team-coordination/README.md
+++ b/project-lifecycle/03-execution/team-coordination/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/03-execution/vendor-management/README.md
+++ b/project-lifecycle/03-execution/vendor-management/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/03-execution/work-management/README.md
+++ b/project-lifecycle/03-execution/work-management/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/04-monitoring-control/change-control/README.md
+++ b/project-lifecycle/04-monitoring-control/change-control/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/04-monitoring-control/performance-measurement/README.md
+++ b/project-lifecycle/04-monitoring-control/performance-measurement/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/05-closure/knowledge-transfer/README.md
+++ b/project-lifecycle/05-closure/knowledge-transfer/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/05-closure/lessons-learned/README.md
+++ b/project-lifecycle/05-closure/lessons-learned/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/05-closure/project-closure/README.md
+++ b/project-lifecycle/05-closure/project-closure/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/project-lifecycle/05-closure/transition-to-operations/README.md
+++ b/project-lifecycle/05-closure/transition-to-operations/README.md
@@ -1,0 +1,9 @@
+# Placeholder directory
+
+This area is currently a placeholder during ongoing reorganization.
+
+Go to canonical templates here:
+- templates/ (all canonical templates)
+
+See NAVIGATION_GUIDE.md for up-to-date guidance on where to find content.
+

--- a/scripts/generate_template_index.mjs
+++ b/scripts/generate_template_index.mjs
@@ -48,7 +48,10 @@ function buildIndexRows(templatesByTitle) {
     const list = templatesByTitle.get(key);
     // Select canonical entry
     const canonical = (() => {
-      // sort by path priority
+      // prefer entries with canonical_path when present
+      const withCanonical = list.find(t => t.canonical_path);
+      if (withCanonical) return withCanonical;
+      // otherwise sort by path priority
       const sorted = [...list].sort((a, b) => {
         const aP = a.path || '';
         const bP = b.path || '';
@@ -66,7 +69,7 @@ function buildIndexRows(templatesByTitle) {
     const methodology = (canonical.methodology || 'universal').toLowerCase();
     const complexity = (canonical.complexity || 'not specified').toLowerCase();
     const updated = canonical.updated || 'Not specified';
-    const link = canonical.path;
+    const link = canonical.canonical_path || canonical.path;
     rows.push(`| ${title} | ${methodology} | ${complexity} | ${updated} | [View](${link}) |`);
   }
   return rows;

--- a/scripts/generate_template_index.mjs
+++ b/scripts/generate_template_index.mjs
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import path from 'path';
+
+// Config
+const ROOT = process.cwd();
+const TEMPLATES_JSON = path.join(ROOT, 'templates', 'templates.json');
+const OUTPUT = path.join(ROOT, 'TEMPLATE_INDEX.md');
+
+function loadTemplates() {
+  const raw = fs.readFileSync(TEMPLATES_JSON, 'utf-8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data.templates)) {
+    throw new Error('Invalid templates.json: missing templates array');
+  }
+  return data.templates;
+}
+
+function pickCanonicalPath(paths) {
+  // Priority order for canonical path selection
+  const priority = [
+    /^templates\//i,
+    /^role-based-toolkits\//i,
+    /^project-lifecycle\//i,
+    /^methodology-frameworks\//i,
+  ];
+  for (const re of priority) {
+    const p = paths.find(p => re.test(p));
+    if (p) return p;
+  }
+  return paths[0];
+}
+
+function groupByTitle(templates) {
+  const map = new Map();
+  for (const t of templates) {
+    const key = String(t.title || '').trim().toLowerCase();
+    if (!key) continue;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(t);
+  }
+  return map;
+}
+
+function buildIndexRows(templatesByTitle) {
+  const rows = [];
+  const keys = Array.from(templatesByTitle.keys()).sort();
+  for (const key of keys) {
+    const list = templatesByTitle.get(key);
+    // Select canonical entry
+    const canonical = (() => {
+      // sort by path priority
+      const sorted = [...list].sort((a, b) => {
+        const aP = a.path || '';
+        const bP = b.path || '';
+        const rank = p => (
+          /^templates\//i.test(p) ? 0 :
+          /^role-based-toolkits\//i.test(p) ? 1 :
+          /^project-lifecycle\//i.test(p) ? 2 :
+          /^methodology-frameworks\//i.test(p) ? 3 : 9
+        );
+        return rank(aP) - rank(bP) || aP.localeCompare(bP);
+      });
+      return sorted[0];
+    })();
+    const title = canonical.title || '(Untitled)';
+    const methodology = (canonical.methodology || 'universal').toLowerCase();
+    const complexity = (canonical.complexity || 'not specified').toLowerCase();
+    const updated = canonical.updated || 'Not specified';
+    const link = canonical.path;
+    rows.push(`| ${title} | ${methodology} | ${complexity} | ${updated} | [View](${link}) |`);
+  }
+  return rows;
+}
+
+function generate() {
+  const templates = loadTemplates();
+  const byTitle = groupByTitle(templates);
+  const header = [
+    '# Template Index',
+    '',
+    '> A comprehensive directory of all project management templates in this repository.',
+    '',
+    'Note: Each entry links to the canonical template location. Where multiple variants exist, the canonical path is preferred; alternate variants may be listed in the template’s Related section.',
+    '',
+    '## 📋 All Templates',
+    '',
+    '| Template | Methodology | Complexity | Updated | Link |',
+    '|----------|-------------|------------|---------|------|',
+  ];
+  const rows = buildIndexRows(byTitle);
+  const content = header.concat(rows).join('\n') + '\n';
+  fs.writeFileSync(OUTPUT, content, 'utf-8');
+  console.log(`Generated ${OUTPUT} with ${rows.length} canonical entries.`);
+}
+
+try {
+  generate();
+} catch (err) {
+  console.error('Failed to generate TEMPLATE_INDEX:', err);
+  process.exit(1);
+}
+

--- a/scripts/template-selector.mjs
+++ b/scripts/template-selector.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+
+function loadIndex(root) {
+  const idxPath = path.join(root, 'templates', 'templates.json');
+  const raw = fs.readFileSync(idxPath, 'utf-8');
+  const data = JSON.parse(raw);
+  if (!Array.isArray(data.templates)) throw new Error('Invalid templates.json: missing templates array');
+  return data.templates;
+}
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const [k, v] = a.split('=');
+      const key = k.replace(/^--/, '');
+      if (typeof v === 'undefined') {
+        // flags without equals consume next token if present and not another flag
+        if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) {
+          args[key] = argv[++i];
+        } else {
+          args[key] = true;
+        }
+      } else {
+        args[key] = v;
+      }
+    }
+  }
+  return args;
+}
+
+function filterTemplates(list, filters) {
+  let out = list;
+  const q = (filters.search || '').toLowerCase();
+  const meth = (filters.methodology || '').toLowerCase();
+  const comp = (filters.complexity || '').toLowerCase();
+  const tagf = (filters.tags || '').toLowerCase();
+
+  if (q) {
+    out = out.filter(t =>
+      (t.title || '').toLowerCase().includes(q) ||
+      (t.path || '').toLowerCase().includes(q)
+    );
+  }
+  if (meth) {
+    out = out.filter(t => (t.methodology || '').toLowerCase() === meth);
+  }
+  if (comp) {
+    out = out.filter(t => (t.complexity || '').toLowerCase() === comp);
+  }
+  if (tagf) {
+    out = out.filter(t => Array.isArray(t.tags) && t.tags.some(tag => String(tag).toLowerCase().includes(tagf)));
+  }
+  return out;
+}
+
+function printList(list, root) {
+  if (!list.length) {
+    console.log('No templates matched.');
+    return;
+  }
+  for (const t of list) {
+    const cols = [
+      t.title || '(Untitled)',
+      t.methodology || 'universal',
+      t.complexity || 'n/a',
+      t.updated || 'n/a',
+      t.path,
+    ];
+    console.log(cols.join(' | '));
+  }
+}
+
+function ensureDir(p) {
+  fs.mkdirSync(p, { recursive: true });
+}
+
+function injectFrontMatter(srcContent, kvPairs) {
+  // kvPairs is { key: value }
+  if (!kvPairs || Object.keys(kvPairs).length === 0) return srcContent;
+  const yamlBlock = Object.entries(kvPairs)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+
+  if (srcContent.startsWith('---\n')) {
+    // Insert before existing closing ---
+    const end = srcContent.indexOf('\n---', 4);
+    if (end !== -1) {
+      const head = srcContent.slice(0, end);
+      const tail = srcContent.slice(end);
+      return `${head}\n${yamlBlock}${tail}`;
+    }
+  }
+  // Prepend a new YAML front matter block
+  return `---\n${yamlBlock}\n---\n\n${srcContent}`;
+}
+
+function parseInjection(str) {
+  // format: key=value,key2=value2
+  const obj = {};
+  if (!str) return obj;
+  const parts = str.split(',');
+  for (const p of parts) {
+    const [k, ...rest] = p.split('=');
+    if (!k) continue;
+    obj[k.trim()] = rest.join('=').trim();
+  }
+  return obj;
+}
+
+function main() {
+  const root = process.cwd();
+  const args = parseArgs(process.argv);
+  const list = loadIndex(root);
+  const filtered = filterTemplates(list, args);
+
+  if (args.list || (!args.copy && !args.title)) {
+    console.log('Title | Methodology | Complexity | Updated | Path');
+    console.log('----- | ----------- | ---------- | ------- | ----');
+    return printList(filtered, root);
+  }
+
+  // Copy mode: --title="Exact Title" --dest=./out --inject="project_name=Acme,owner=Jane Doe"
+  const title = args.title;
+  const dest = args.dest || '.';
+  if (!title) {
+    console.error('Error: --title is required for copy mode');
+    process.exit(1);
+  }
+  const matches = filtered.filter(t => (t.title || '').toLowerCase() === String(title).toLowerCase());
+  if (!matches.length) {
+    console.error('No template found with title:', title);
+    process.exit(2);
+  }
+  // Prefer canonical path like earlier generator priority
+  const ordered = matches.sort((a, b) => {
+    const rank = p => (/^templates\//i.test(p) ? 0 : /^role-based-toolkits\//i.test(p) ? 1 : /^project-lifecycle\//i.test(p) ? 2 : /^methodology-frameworks\//i.test(p) ? 3 : 9);
+    return rank(a.path) - rank(b.path) || a.path.localeCompare(b.path);
+  });
+  const choice = ordered[0];
+  const srcPath = path.join(root, choice.path);
+  if (!fs.existsSync(srcPath)) {
+    console.error('Source file not found:', srcPath);
+    process.exit(3);
+  }
+  const baseName = path.basename(srcPath);
+  const dstDir = path.resolve(dest);
+  ensureDir(dstDir);
+  const dstPath = path.join(dstDir, baseName);
+  let content = fs.readFileSync(srcPath, 'utf-8');
+  const injectObj = parseInjection(args.inject || '');
+  if (Object.keys(injectObj).length) {
+    content = injectFrontMatter(content, injectObj);
+  }
+  fs.writeFileSync(dstPath, content, 'utf-8');
+  console.log('Copied:', choice.title, '\nFrom:', choice.path, '\nTo  :', dstPath);
+}
+
+try { main(); } catch (err) {
+  console.error('template-selector error:', err);
+  process.exit(1);
+}
+

--- a/scripts/template-selector.mjs
+++ b/scripts/template-selector.mjs
@@ -137,11 +137,14 @@ function main() {
   }
   // Prefer canonical path like earlier generator priority
   const ordered = matches.sort((a, b) => {
+    // prefer canonical_path if present
+    const aPath = a.canonical_path || a.path;
+    const bPath = b.canonical_path || b.path;
     const rank = p => (/^templates\//i.test(p) ? 0 : /^role-based-toolkits\//i.test(p) ? 1 : /^project-lifecycle\//i.test(p) ? 2 : /^methodology-frameworks\//i.test(p) ? 3 : 9);
-    return rank(a.path) - rank(b.path) || a.path.localeCompare(b.path);
+    return rank(aPath) - rank(bPath) || aPath.localeCompare(bPath);
   });
   const choice = ordered[0];
-  const srcPath = path.join(root, choice.path);
+  const srcPath = path.join(root, choice.canonical_path || choice.path);
   if (!fs.existsSync(srcPath)) {
     console.error('Source file not found:', srcPath);
     process.exit(3);

--- a/templates/README.md
+++ b/templates/README.md
@@ -133,14 +133,18 @@ Check: `test-samples/` → Real-world template applications and case studies
 ## 🛠️ **Template Formats & Tools**
 
 ### **📄 Available Formats**
-| Format | Best For | Tools |
-|--------|----------|-------|
-| **Microsoft Word** | Documents, reports, plans | Word, Google Docs |
-| **Microsoft Excel** | Calculations, tracking, analysis | Excel, Google Sheets |
-| **Microsoft PowerPoint** | Presentations, dashboards | PowerPoint, Google Slides |
-| **PDF** | Printed forms, official documents | Any PDF reader |
-| **CSV** | Data import/export | Any spreadsheet tool |
-| **Markdown** | Version-controlled documentation | Git, GitHub, text editors |
+| Format | Availability | Best For | Tools |
+|--------|--------------|----------|-------|
+| **Markdown** | Common | Version-controlled documentation | Git, GitHub, text editors |
+| **Microsoft Excel** | Select templates (see templates/excel) | Calculations, tracking, analysis | Excel, Google Sheets |
+| **Microsoft Word** | Limited | Documents, reports, plans | Word, Google Docs |
+| **Microsoft PowerPoint** | Limited | Presentations, dashboards | PowerPoint, Google Slides |
+| **PDF** | Export only (as needed) | Printed forms, official documents | Any PDF reader |
+| **CSV** | As provided | Data import/export | Any spreadsheet tool |
+
+Notes
+- Office formats (Word/PowerPoint) are not universally available; prefer Markdown for portability and Excel for calculators/dashboards where present (see templates/excel/).
+- If you contribute Office versions, include both the source file and a Markdown overview.
 
 ### **🔧 Tool Integration**
 - **Project Management Tools** - Import into JIRA, Asana, Monday.com, etc.
@@ -224,6 +228,12 @@ Check: `test-samples/` → Real-world template applications and case studies
 - [`/examples/`](../examples/) - Real-world template applications
 
 ---
+
+## ♿ **Accessibility**
+
+- Follow the Accessibility Checklist: see docs/accessibility.md
+- Use true headings, descriptive links, alt text, and sufficient contrast
+- Prefer canonical links and simple, readable layouts
 
 ## 📞 **Support & Contribution**
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -23,7 +23,7 @@ This is your central template repository containing the most frequently used and
 templates/
 ├── agile/              # Agile-specific template variations
 ├── hybrid/             # Hybrid methodology templates
-├── traditional/        # Traditional/PMBOK template variations
+├── traditional/        # Traditional template variations
 └── test-samples/       # Example implementations and demos
 ```
 
@@ -43,7 +43,7 @@ Begin with: **Project Initiation Templates** → Charter, stakeholder analysis, 
 
 ### **2. Know Your Methodology?**
 - **Agile Projects:** → `agile/` directory for sprint-based templates
-- **Traditional Projects:** → `traditional/` directory for PMBOK-aligned templates  
+- **Traditional Projects:** → `traditional/` directory for Traditional-aligned templates  
 - **Mixed Approach:** → `hybrid/` directory for combined methodology templates
 
 ### **3. Need Specific Template Type?**
@@ -213,7 +213,7 @@ Check: `test-samples/` → Real-world template applications and case studies
 
 ### **Within This Repository:**
 - [`/Agile/`](../Agile/) - Complete agile methodology toolkit
-- [`/Traditional/`](../Traditional/) - Full PMBOK-aligned resources
+- [`/Traditional/`](../Traditional/) - Full Traditional-aligned resources
 - [`/Hybrid/`](../Hybrid/) - Hybrid methodology frameworks
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific template collections
 - [`/industry-specializations/`](../industry-specializations/) - Industry-adapted templates

--- a/templates/hybrid/Hybrid/README.md
+++ b/templates/hybrid/Hybrid/README.md
@@ -1,6 +1,6 @@
 # Hybrid Project Management Templates & Tools
 
-> **Best of Both Worlds** - Intelligently combine Traditional (PMBOK) structure with Agile flexibility for optimal project outcomes across diverse organizational contexts.
+> **Best of Both Worlds** - Intelligently combine Traditional structure with Agile flexibility for optimal project outcomes across diverse organizational contexts.
 
 ---
 
@@ -57,7 +57,7 @@ Check: `Tools/` → Methodology selection and maturity assessment tools
 
 ### **🏗️ Traditional Planning → Agile Execution**
 **Best For:** Large programs, fixed budgets, regulatory requirements
-- **Phase 1:** Traditional initiation and detailed planning (PMBOK)
+- **Phase 1:** Traditional initiation and detailed planning
 - **Phase 2:** Agile execution with sprints and iterations
 - **Phase 3:** Traditional closure and governance reporting
 
@@ -276,7 +276,7 @@ Located in: `MPP-Jira-Integration/`
 
 ### **Within This Repository:**
 - [`/Agile/`](../Agile/) - Pure agile methodology templates and tools
-- [`/Traditional/`](../Traditional/) - PMBOK-aligned traditional project management
+- [`/Traditional/`](../Traditional/) - Traditional-aligned project management
 - [`/role-based-toolkits/`](../role-based-toolkits/) - Role-specific hybrid tools
 - [`/methodology-frameworks/`](../methodology-frameworks/) - Comparative methodology guidance
 

--- a/templates/traditional/Traditional/README.md
+++ b/templates/traditional/Traditional/README.md
@@ -1,6 +1,6 @@
 # Traditional Project Management Templates & Tools
 
-> **PMBOK-Aligned Excellence** - Comprehensive templates and tools based on PMI standards, waterfall methodology, and traditional project management best practices.
+> **Traditional-Aligned Excellence** - Comprehensive templates and tools based on PMI standards, waterfall methodology, and traditional project management best practices.
 
 ---
 
@@ -169,7 +169,7 @@ Explore: `Templates/program-management/` → Multi-project coordination tools
 
 ---
 
-## 🎓 **PMBOK Alignment & Best Practices**
+## 🎓 **Traditional Alignment & Best Practices**
 
 ### **PMI Standards Integration**
 - **PMBOK Guide 7th Edition** - Process-based and principles-based approaches
@@ -293,5 +293,5 @@ Explore: `Templates/program-management/` → Multi-project coordination tools
 
 **Last Updated:** August 2025  
 **Maintained By:** PM Tools Templates Community  
-**PMBOK Version:** 7th Edition Aligned  
+**Standards Alignment:** PMBOK® 7th Edition  
 **Certification:** PMP®-Aligned Templates


### PR DESCRIPTION
Summary\n- Update scripts/generate_template_index.mjs and scripts/template-selector.mjs to prefer canonical_path when present\n\nWhy\n- Prepares the tooling to use canonical_path/alternate_paths once templates/templates.json is enriched, while maintaining backward compatibility via path priority fallback\n\nNext\n- Enrich templates/templates.json with canonical_path and alternate_paths fields (separate PR)