### PR TITLE
docs(deployer): minimal READMEs for Jira/Asana deployers

### DIFF
--- a/integrations/deployer/asana/README.md
+++ b/integrations/deployer/asana/README.md
@@ -1,14 +1,27 @@
-# Asana Deployer Scaffold (Issue #290)
+# Asana Deployer (Minimal)
 
-Purpose
-- Minimal project deployer to create an Asana project from a simple template.
+Public-facing CLI to create a minimal Asana project with optional seed tasks.
+Dry-run by default; write mode requires a bearer token via environment variable.
 
-Checklist (Phase 1)
-- [ ] Define minimal template schema (project name, tasks, simple dependencies)
-- [ ] Create project (POST /projects)
-- [ ] Create tasks/subtasks; set basic dependencies
-- [ ] Basic error handling and rollback on failure
-- [ ] Audit logging for deploy events
+Requirements
+- Node.js 18+ recommended
+- ASANA_BEARER set to a valid Asana access token (write mode only)
 
-Next
-- Support custom field creation/mapping and team/workspace assignment
+Usage
+- Dry-run (no writes):
+```
+npm --prefix integrations/deployer/asana run dev
+```
+- Write mode (guarded):
+```
+ASANA_BEARER={{ASANA_ACCESS_TOKEN}} npm --prefix integrations/deployer/asana run deploy
+```
+Optional flags
+- --workspace=WORKSPACE_GID (if omitted, uses the first workspace from your account)
+
+Environment variables
+- ASANA_PROJECT_NAME: project name (default: "PM Tools Demo")
+
+Notes
+- Do not echo or commit secrets. Set tokens via environment variables only.
+- This is a minimal deployer intended for demos and scaffolding. Extend as needed for your org.

--- a/integrations/deployer/jira/README.md
+++ b/integrations/deployer/jira/README.md
@@ -1,14 +1,29 @@
-# Jira Deployer Scaffold (Issue #290)
+# Jira Deployer (Minimal)
 
-Purpose
-- Minimal project deployer to create a Jira project from a simple template.
+Public-facing CLI to create a minimal Jira project from a simple template.
+Dry-run by default; write mode requires a bearer token via environment variable.
 
-Checklist (Phase 1)
-- [ ] Define minimal template schema (name, key, issue types)
-- [ ] Create project via REST (POST /rest/api/3/project)
-- [ ] Create issue types/fields if missing; idempotent operations
-- [ ] Basic error handling and rollback on failure
-- [ ] Audit logging for deploy events
+Requirements
+- Node.js 18+ recommended
+- JIRA_BEARER set to a valid Atlassian access token (write mode only)
 
-Next
-- Support workflow scheme assignment and permissions mapping
+Usage
+- Dry-run (no writes):
+```
+npm --prefix integrations/deployer/jira run dev
+```
+- Write mode (guarded):
+```
+JIRA_BEARER={{JIRA_ACCESS_TOKEN}} npm --prefix integrations/deployer/jira run deploy
+```
+Optional flags
+- --cloud-id=YOUR_CLOUD_ID (otherwise auto-detected)
+- --project-type=software|service_desk|business (default: software)
+
+Environment variables
+- JIRA_PROJECT_NAME: project name (default: "PM Tools Demo")
+- JIRA_PROJECT_KEY: 2–10 uppercase letters (default: "PMD")
+
+Notes
+- Do not echo or commit secrets. Set tokens via environment variables only.
+- This is a minimal deployer intended for demos and scaffolding. Extend as needed for your org.


### PR DESCRIPTION
Adds concise, public-facing README.md files for the deployers with dry-run and guarded write-mode usage examples.\n\n- integrations/deployer/jira/README.md\n- integrations/deployer/asana/README.md\n\nNo secrets; tokens provided via env vars only. No working notes included.