### PR TITLE
build(deps): bump vitest in deployer workspaces

### DIFF
--- a/integrations/deployer/asana/package.json
+++ b/integrations/deployer/asana/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "tsx": "^4.16.2",
-    "vitest": "^2.0.5",
+    "vitest": "^3.2.6",
     "@types/node": "^20.11.30"
   }
 }

--- a/integrations/deployer/jira/package.json
+++ b/integrations/deployer/jira/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "tsx": "^4.16.2",
-    "vitest": "^2.0.5",
+    "vitest": "^3.2.6",
     "@types/node": "^20.11.30"
   }
 }


### PR DESCRIPTION
## Summary
- Upgrade Vitest from ^2.0.5 to ^3.2.6 in the Jira and Asana deployer workspaces.
- Keep the change limited to the two intended manifest files.

## Validation
- npm install --package-lock=false --no-audit --no-fund --loglevel=warn
- npm test

## Notes
- The deployer workspaces currently contain no Vitest test files, so the test command exits with 'No test files found'.
- Expected alerts to close: #558, #557.
- No root package-lock.json changes were introduced.

## Risks
- None beyond the current lack of test files in these workspaces.