### PR TITLE
fix(security): remediate requirements CLI dependency alerts

### DIFF
--- a/tools/requirements-structuring-cli/package-lock.json
+++ b/tools/requirements-structuring-cli/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "pm-requirements-structuring",
-  "version": "file:../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pm-requirements-structuring",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.0",
-        "axios": "^1.12.0",
+        "axios": "^1.18.0",
         "chalk": "^4.1.2",
         "commander": "^11.0.0",
         "dotenv": "^16.3.0",
@@ -25,7 +25,7 @@
         "node": ">=16.0.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/@google/generative-ai": {
+    "node_modules/@google/generative-ai": {
       "version": "0.24.1",
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
       "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
@@ -34,7 +34,7 @@
         "node": ">=18.0.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/@inquirer/external-editor": {
+    "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
       "integrity": "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==",
@@ -55,7 +55,19 @@
         }
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/ansi-escapes": {
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
@@ -70,7 +82,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/ansi-regex": {
+    "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
@@ -79,7 +91,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/ansi-styles": {
+    "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
@@ -94,24 +106,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/asynckit": {
+    "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/base64-js": {
+    "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
@@ -131,7 +144,7 @@
       ],
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/bl": {
+    "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
@@ -142,7 +155,7 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/buffer": {
+    "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
@@ -166,7 +179,7 @@
         "ieee754": "^1.1.13"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/call-bind-apply-helpers": {
+    "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
@@ -179,7 +192,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/chalk": {
+    "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -195,13 +208,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/cli-cursor": {
+    "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
@@ -213,7 +226,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/cli-spinners": {
+    "node_modules/cli-spinners": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
@@ -225,7 +238,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/cli-width": {
+    "node_modules/cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
@@ -234,7 +247,7 @@
         "node": ">= 10"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/clone": {
+    "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
@@ -243,7 +256,7 @@
         "node": ">=0.8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/color-convert": {
+    "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
@@ -255,13 +268,13 @@
         "node": ">=7.0.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/color-name": {
+    "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/combined-stream": {
+    "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
@@ -273,7 +286,7 @@
         "node": ">= 0.8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/commander": {
+    "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
@@ -282,7 +295,24 @@
         "node": ">=16"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/defaults": {
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
       "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
@@ -294,7 +324,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/delayed-stream": {
+    "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
@@ -303,7 +333,7 @@
         "node": ">=0.4.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/dotenv": {
+    "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
@@ -315,7 +345,7 @@
         "url": "https://dotenvx.com"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/dunder-proto": {
+    "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
@@ -329,13 +359,13 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/emoji-regex": {
+    "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/es-define-property": {
+    "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
@@ -344,7 +374,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/es-errors": {
+    "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
@@ -353,10 +383,10 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -365,7 +395,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/es-set-tostringtag": {
+    "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
@@ -380,7 +410,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/escape-string-regexp": {
+    "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
@@ -389,7 +419,7 @@
         "node": ">=0.8.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/figures": {
+    "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
@@ -404,10 +434,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -424,26 +454,26 @@
         }
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -454,7 +484,7 @@
         "node": ">=14.14"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/function-bind": {
+    "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
@@ -463,7 +493,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/get-intrinsic": {
+    "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
@@ -487,7 +517,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/get-proto": {
+    "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
@@ -500,7 +530,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/gopd": {
+    "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
@@ -512,13 +542,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/graceful-fs": {
+    "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/has-flag": {
+    "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
@@ -527,7 +557,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/has-symbols": {
+    "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
@@ -539,7 +569,7 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/has-tostringtag": {
+    "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
@@ -554,10 +584,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -566,10 +596,23 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -582,7 +625,7 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/ieee754": {
+    "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
@@ -602,13 +645,13 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/inquirer": {
+    "node_modules/inquirer": {
       "version": "8.2.7",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
       "integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
@@ -634,7 +677,7 @@
         "node": ">=12.0.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/is-fullwidth-code-point": {
+    "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
@@ -643,7 +686,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/is-interactive": {
+    "node_modules/is-interactive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
@@ -652,7 +695,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/is-unicode-supported": {
+    "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
@@ -664,10 +707,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -676,13 +719,13 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/log-symbols": {
+    "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
@@ -698,7 +741,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/math-intrinsics": {
+    "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
@@ -707,7 +750,7 @@
         "node": ">= 0.4"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/mime-db": {
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
@@ -716,7 +759,7 @@
         "node": ">= 0.6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
@@ -728,7 +771,7 @@
         "node": ">= 0.6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/mimic-fn": {
+    "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
@@ -737,13 +780,19 @@
         "node": ">=6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/mute-stream": {
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "license": "ISC"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/onetime": {
+    "node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
@@ -758,7 +807,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/ora": {
+    "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
       "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
@@ -781,13 +830,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/readable-stream": {
+    "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
@@ -801,7 +853,7 @@
         "node": ">= 6"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/restore-cursor": {
+    "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
@@ -814,7 +866,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/run-async": {
+    "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
@@ -823,7 +875,7 @@
         "node": ">=0.12.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/rxjs": {
+    "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
@@ -832,7 +884,7 @@
         "tslib": "^2.1.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/safe-buffer": {
+    "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
@@ -852,19 +904,19 @@
       ],
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/safer-buffer": {
+    "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/signal-exit": {
+    "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
@@ -873,7 +925,7 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/string-width": {
+    "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
@@ -887,7 +939,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/strip-ansi": {
+    "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -899,7 +951,7 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/supports-color": {
+    "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -911,19 +963,19 @@
         "node": ">=8"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/through": {
+    "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/tslib": {
+    "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/type-fest": {
+    "node_modules/type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
@@ -935,7 +987,7 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/universalify": {
+    "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
@@ -944,13 +996,13 @@
         "node": ">= 10.0.0"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/util-deprecate": {
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/wcwidth": {
+    "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
       "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
@@ -959,7 +1011,7 @@
         "defaults": "^1.0.3"
       }
     },
-    "../../../../../Volumes/michael_share/pm-tools-templates/tools/requirements-structuring-cli/node_modules/wrap-ansi": {
+    "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",

--- a/tools/requirements-structuring-cli/package.json
+++ b/tools/requirements-structuring-cli/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@google/generative-ai": "^0.24.0",
-    "axios": "^1.12.0",
+    "axios": "^1.18.0",
     "chalk": "^4.1.2",
     "commander": "^11.0.0",
     "dotenv": "^16.3.0",


### PR DESCRIPTION
Security-remediation campaign context: This PR is part of the repository-wide dependabot remediation freeze and addresses the 32 alerts assigned to tools/requirements-structuring-cli.\n\nAlerts expected to close: #361, #362, #398, #399, #406, #450, #451, #452, #453, #454, #455, #456, #457, #458, #459, #460, #461, #462, #543, #545, #546, #550, #552, #553, #554, #601, #682, #683, #684, #685, #686, #687.\n\nDependency versions before and after:\n- axios: 1.13.6 -> 1.19.0\n- follow-redirects: 1.15.11 -> 1.16.0\n- form-data: 4.0.5 -> 4.0.6\n- lodash: 4.17.23 -> 4.18.1\n\nDirect dependency changes:\n- Updated axios range from ^1.12.0 to ^1.18.0.\n\nNo override was required; normal npm resolution selected patched versions for follow-redirects, form-data, and lodash.\n\nLockfile regeneration: package-lock.json was deleted and recreated with npm install --package-lock-only --ignore-scripts to eliminate polluted /Volumes/ paths and restore a clean workspace-relative lockfile.\n\nConfirmed external path removal: no /Volumes/, /private/tmp/, pm-sparse, or absolute workspace-escaping package keys remain in the regenerated lockfile.\n\nExact commands executed:\n- git fetch origin main\n- git switch main\n- git pull --ff-only origin main\n- git switch -c security/requirements-structuring-alerts\n- cd tools/requirements-structuring-cli\n- rm -f package-lock.json\n- npm install --package-lock-only --ignore-scripts\n- npm ci\n- npm ls axios follow-redirects form-data lodash --all\n- npm explain axios\n- npm explain follow-redirects\n- npm explain form-data\n- npm explain lodash\n- npm test\n- npm run validate\n\nInstallation, test, and validation results:\n- npm ci succeeded\n- npm test succeeded with 29 passed\n- npm run validate succeeded\n\nExact changed-file list:\n- tools/requirements-structuring-cli/package.json\n- tools/requirements-structuring-cli/package-lock.json\n\nExpected alert reduction: 32\nExpected repository total after merge: 111, subject to no new alerts\n\nGitHub alert closure must be verified after merge; this PR does not itself confirm closure.\n\nUncertainty or unresolved risk: GitHub Dependabot API access was unavailable from this environment (HTTP 403), so the live alert list could not be validated pre-change.\n\nDo not merge until Codex review and repository-owner approval are complete.