### PR TITLE
chore(frontend): update form-data to 4.0.6

### DIFF
--- a/Snowflake Demo/frontend/package-lock.json
+++ b/Snowflake Demo/frontend/package-lock.json
@@ -1669,16 +1669,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2120,9 +2120,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"


### PR DESCRIPTION
## Campaign context

This draft PR is the Snowflake frontend step in the repository-wide Dependabot alert-closure campaign.

## Alert addressed

- #585 — form-data CRLF injection
- Vulnerable range: form-data >=4.0.0 <4.0.6
- Required patched version: 4.0.6

## Dependency trace

- Direct frontend dependency: axios@1.18.0
- Transitive dependency: form-data
- Axios permits form-data through range ^4.0.5, which naturally selects 4.0.6
- No manifest change or npm override was required

## Version change

- form-data: 4.0.5 → 4.0.6
- hasown: 2.0.2 → 2.0.4 as a direct form-data compatibility dependency

No package was downgraded.

## Lockfile update

- Runtime: Node 20.20.2 / npm 10.8.2
- Command: npm update form-data
- package.json remained unchanged
- package-lock.json parses successfully
- No polluted or external-path package keys remain
- No vulnerable form-data 4.x instance remains

## Validation

- npm ci: passed, exit 0
- npm test: failed, exit 127, with `react-scripts: not found`
- npm run build: failed, exit 127, with `react-scripts: not found`

## Base comparison

Base commit:

`c2f1a2448af1289a4e01d0a3c715d0d91c461e3e`

Under the same Node/npm environment:

- Base npm ci: passed
- Base npm test: exit 127 with `react-scripts: not found`
- Base npm run build: exit 127 with `react-scripts: not found`

PR #1019 introduces no new test or build failure.

## Changed files

- Snowflake Demo/frontend/package-lock.json

## Expected alert impact

- Expected closure: alert #585
- Expected remaining Dependabot alerts after merge: 1, subject to no new or independently closed alerts

## Post-merge verification requirement

Closure must be confirmed through the live Dependabot API after merge. Do not claim closure based only on the lockfile or npm output.

Do not merge until Codex review and repository-owner approval are complete.
