### PR TITLE
fix: generate and upload Semgrep SARIF

### DIFF
--- a/.github/workflows/sast-security.yml
+++ b/.github/workflows/sast-security.yml
@@ -388,7 +388,7 @@ jobs:
         with:
           path: |
             ~/.cache/semgrep
-            ~/.local/bin/semgrep
+            ~/.cache/pip
             ~/.trivy
           key: security-tools-${{ runner.os }}-v1
           restore-keys: |
@@ -414,6 +414,7 @@ jobs:
           RULES=()
           
           # Base security rules (always included)
+          RULES+=("p/github-actions")
           RULES+=("p/security-audit")
           RULES+=("p/secrets")
           RULES+=("p/owasp-top-ten")
@@ -468,19 +469,57 @@ jobs:
           
           echo "🛡️ Configured rules: $RULES_STRING"
 
+      - name: 📦 Install Semgrep CLI
+        run: |
+          pipx install --force semgrep
+
       - name: 🛡️ Run Semgrep SAST
-        uses: semgrep/semgrep-action@v1
         continue-on-error: true
-        with:
-          config: ${{ steps.configure.outputs.rules }}
         env:
           SEMGREP_TIMEOUT: ${{ env.SEMGREP_TIMEOUT }}
           SEMGREP_RULES: ${{ steps.configure.outputs.rules }}
-          # SEMGREP_APP_TOKEN is optional for basic usage
-          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        run: |
+          semgrep scan --sarif-output=semgrep.sarif .
+
+      - name: ✅ Verify Semgrep SARIF
+        if: always()
+        run: |
+          if [[ ! -s semgrep.sarif ]]; then
+            echo "semgrep.sarif is missing or empty" >&2
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          sarif_path = "semgrep.sarif"
+
+          try:
+              with open(sarif_path, "r", encoding="utf-8") as sarif_file:
+                  sarif = json.load(sarif_file)
+          except Exception as exc:
+              print(f"Failed to parse {sarif_path} as JSON: {exc}", file=sys.stderr)
+              raise SystemExit(1)
+
+          if sarif.get("version") != "2.1.0":
+              print(
+                  f"Unexpected SARIF version in {sarif_path}: {sarif.get('version')!r}",
+                  file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          runs = sarif.get("runs")
+          if not isinstance(runs, list):
+              print(f"Invalid SARIF runs in {sarif_path}: expected a list", file=sys.stderr)
+              raise SystemExit(1)
+
+          print(f"Validated {sarif_path} ({os.path.getsize(sarif_path)} bytes)")
+          PY
 
       - name: 📤 Upload Semgrep SARIF
-        if: always() && hashFiles('semgrep.sarif') != ''
+        if: always()
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Problem statement
The default-branch Semgrep scan currently completes, but the `Upload Semgrep SARIF` step is skipped because `semgrep.sarif` is never created. That means GitHub receives no replacement Semgrep code-scanning analysis for the merge commit, so it cannot reconcile the 17 historical GitHub Actions injection alerts.

## Root cause
The workflow still uses the deprecated `semgrep/semgrep-action@v1` wrapper. In this repository’s current configuration, the wrapper succeeds without creating `semgrep.sarif`, and the upload step is guarded by `hashFiles('semgrep.sarif') != ''`, so the failure is hidden as a skipped upload instead of surfacing visibly.

## Starting point
- Starting `main` SHA: `bd82735a385ce496f3d12396cfea965c0a604764`
- Branch: `security/semgrep-sarif-upload`
- Changed file: `.github/workflows/sast-security.yml`

## What changed
- Removed the deprecated `semgrep/semgrep-action@v1` wrapper.
- Added explicit Semgrep CLI installation with `pipx install --force semgrep`.
- Added explicit SARIF generation with `semgrep scan --sarif-output=semgrep.sarif .`.
- Added `p/github-actions` to the Semgrep ruleset while preserving the existing rulesets.
- Replaced the Semgrep cache entry for `~/.local/bin/semgrep` with `~/.cache/pip` while preserving the other cache paths and keys.
- Added explicit SARIF validation that:
  - requires `semgrep.sarif` to exist and be nonempty
  - parses it as JSON with Python
  - requires SARIF version `2.1.0`
  - requires `runs` to be a list
  - prints the file size on success
  - fails clearly if the SARIF file is missing or invalid
- Preserved the SARIF upload category as `semgrep`.
- Changed SARIF verification and upload to unconditional `if: always()` so missing SARIF fails visibly instead of silently skipping upload.

## Local validation commands and exit codes
1. `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML_OK"' .github/workflows/sast-security.yml`
   - exit code: `0`
2. `/go/bin/actionlint .github/workflows/sast-security.yml`
   - exit code: `0`
3. Baseline comparison workflow extraction:
   - `git show bd82735a385ce496f3d12396cfea965c0a604764:.github/workflows/sast-security.yml > "$TMPDIR/sast-security.yml"`
   - `/go/bin/actionlint "$TMPDIR/sast-security.yml"`
   - exit code: `0`
4. `diff -u "$BASE_OUT" "$CURRENT_OUT"`
   - exit code: `0`
   - result: no new branch-only `actionlint` finding
5. `git diff --check`
   - exit code: `0`
6. `git diff --name-only`
   - exit code: `0`
   - result: only `.github/workflows/sast-security.yml` changed
7. Presence checks for required content
   - exit code: `0`
   - confirmed: `p/github-actions`, `pipx install --force semgrep`, `semgrep scan --sarif-output=semgrep.sarif .`, SARIF JSON verification, `category: semgrep`, unconditional `if: always()` on verification and upload
8. Absence check for deprecated references
   - exit code: `1`
   - result: `semgrep/semgrep-action@v1`, `SEMGREP_APP_TOKEN`, and `hashFiles('semgrep.sarif')` are absent as required

## Local SARIF-generation test
Performed outside the repository with temporary artifacts only.

1. Temporary install:
   - `PIPX_HOME="$TMPROOT/pipx-home" PIPX_BIN_DIR="$TMPROOT/pipx-bin" pipx install --force semgrep`
   - exit code: `0`
2. Temporary scan:
   - `PATH="$PIPX_BIN_DIR:$PATH" SEMGREP_RULES='p/github-actions' semgrep scan --sarif-output="$TMPROOT/semgrep.sarif" .github/workflows`
   - exit code: `0`
3. Temporary SARIF verification:
   - exit code: `0`
   - verified: file exists, nonempty, parses as JSON, SARIF version `2.1.0`, `runs` exists
   - verified target rule result count is zero for:
     - `yaml.github-actions.security.run-shell-injection.run-shell-injection`
     - `yaml.github-actions.security.github-script-injection.github-script-injection`

## GitHub-hosted PR verification
- SAST workflow run: `31543640703`
- `📦 Install Semgrep CLI`: success
- `🛡️ Run Semgrep SAST`: success
- `✅ Verify Semgrep SARIF`: success
- `📤 Upload Semgrep SARIF`: success
- `CodeQL`: success
- `Semgrep`: success
- `Advanced Security`: success
- The upload step executed and was not skipped.

## Failures or uncertainties
- Local tooling note: `actionlint` was not preinstalled and was installed locally via `go install github.com/rhysd/actionlint/cmd/actionlint@latest` for validation.
- Local Semgrep temporary scan reported `Targets scanned: 0` for `.github/workflows` while still producing valid SARIF with zero target-rule results. Because of that local behavior, the GitHub-hosted PR workflow run is the authoritative end-to-end verification for SARIF creation, upload execution, analysis category, and target finding count.
- GitHub code-scanning analysis and alert API queries from this environment returned `HTTP 403 Resource not accessible by integration`, so live API verification of the PR-head analysis category, PR-head alert list, and the 17 historical alert records is blocked here pending repository-owner credentials or a different token scope.
- The 17 historical alerts remain open until this change is merged and a fresh default-branch Semgrep SARIF upload is recorded on GitHub.

## Historical alerts still open
#1006, #1007, #1008, #1009, #1010, #1011, #1012, #1013, #1014, #1015, #1017, #1018, #1019, #1020, #1021, #1022, #1024

## Merge guidance
Do not merge this PR before Codex review and repository-owner approval. This PR must remain draft until the GitHub-hosted checks confirm that the Semgrep job installs the CLI, generates `semgrep.sarif`, validates it successfully, uploads it successfully without skipping, records a Semgrep analysis with category `semgrep`, and reports zero target injection findings on the PR head.
