### PR TITLE
fix: reconcile Semgrep SARIF tool identity

### DIFF
--- a/.github/workflows/sast-security.yml
+++ b/.github/workflows/sast-security.yml
@@ -511,11 +511,54 @@ jobs:
               raise SystemExit(1)
 
           runs = sarif.get("runs")
-          if not isinstance(runs, list):
-              print(f"Invalid SARIF runs in {sarif_path}: expected a list", file=sys.stderr)
+          if not isinstance(runs, list) or not runs:
+              print(f"Invalid SARIF runs in {sarif_path}: expected a nonempty list", file=sys.stderr)
               raise SystemExit(1)
 
-          print(f"Validated {sarif_path} ({os.path.getsize(sarif_path)} bytes)")
+          for run in runs:
+              tool = run.get("tool") if isinstance(run, dict) else None
+              driver = tool.get("driver") if isinstance(tool, dict) else None
+              if not isinstance(driver, dict):
+                print(
+                  f"Invalid SARIF run in {sarif_path}: missing tool.driver object",
+                  file=sys.stderr,
+                )
+                raise SystemExit(1)
+              driver["name"] = "Semgrep"
+
+          with open(sarif_path, "w", encoding="utf-8") as sarif_file:
+              json.dump(sarif, sarif_file, indent=2)
+              sarif_file.write("\n")
+
+          try:
+              with open(sarif_path, "r", encoding="utf-8") as sarif_file:
+                normalized_sarif = json.load(sarif_file)
+          except Exception as exc:
+              print(f"Failed to re-parse normalized {sarif_path} as JSON: {exc}", file=sys.stderr)
+              raise SystemExit(1)
+
+          normalized_runs = normalized_sarif.get("runs")
+          if not isinstance(normalized_runs, list) or not normalized_runs:
+              print(
+                f"Invalid normalized SARIF runs in {sarif_path}: expected a nonempty list",
+                file=sys.stderr,
+              )
+              raise SystemExit(1)
+
+          for run in normalized_runs:
+              tool = run.get("tool") if isinstance(run, dict) else None
+              driver = tool.get("driver") if isinstance(tool, dict) else None
+              if not isinstance(driver, dict) or driver.get("name") != "Semgrep":
+                print(
+                  f"Invalid normalized SARIF tool.driver.name in {sarif_path}: expected 'Semgrep'",
+                  file=sys.stderr,
+                )
+                raise SystemExit(1)
+
+          print(
+              f"Normalized {len(normalized_runs)} SARIF runs to Semgrep "
+              f"({os.path.getsize(sarif_path)} bytes)"
+          )
           PY
 
       - name: 📤 Upload Semgrep SARIF


### PR DESCRIPTION
## Campaign context
PR #1022 remediated the GitHub Actions workflow injection findings. PR #1023 repaired Semgrep SARIF generation and upload, and merged as `8a828cb075085c441d7025517b3c98527a37f86f`. The post-merge default-branch workflow generated, validated, and uploaded `semgrep.sarif` under category `semgrep`, but GitHub still left the 17 historical alerts open.

Target alerts: #1006, #1007, #1008, #1009, #1010, #1011, #1012, #1013, #1014, #1015, #1017, #1018, #1019, #1020, #1021, #1022, #1024.

## Root cause
The new default-branch analysis uses tool name `Semgrep OSS`, while the historical alerts use tool name `Semgrep`. The category `semgrep` and analysis key `.github/workflows/sast-security.yml:semgrep-analysis` already match, so the differing tool identity prevents reconciliation.

## Change
- Starting main SHA: `8a828cb075085c441d7025517b3c98527a37f86f`
- Branch: `security/semgrep-tool-name-reconciliation`
- Commit: `00e5b0d5d12fdf85e7b8676664693130ca82778d`
- Exact changed file: `.github/workflows/sast-security.yml`
- Extend the existing SARIF verification heredoc after Semgrep scan and before upload.
- Require a nonempty SARIF `runs` list and a `tool.driver` object in every run.
- Set every `runs[].tool.driver.name` to exactly `Semgrep`.
- Rewrite `semgrep.sarif`, reopen and parse it, then fail unless every final driver name is `Semgrep`.
- Print the normalized run count and final file size.
- Preserve the existing Semgrep configuration, scan target, upload action, category `semgrep`, job name, workflow identity, and unconditional upload behavior.

## Local validation
- YAML parse with Python `yaml.safe_load`: exit `0` (`YAML_OK`).
- `actionlint .github/workflows/sast-security.yml`: exit `0`.
- Exact embedded Python heredoc compilation with `python3 -m py_compile`: exit `0`.
- `git diff --check`: exit `0`.
- Changed-file verification: only `.github/workflows/sast-security.yml`.
- Repository artifact check: no SARIF or install artifacts present.
- Temporary Semgrep install with `pipx install --force semgrep`: exit `0`.
- Temporary `SEMGREP_RULES='p/github-actions' semgrep scan --sarif-output=<tmp>/semgrep.sarif .github/workflows`: exit `0`.
- Temporary normalization and final SARIF verification: exit `0`.
- Final temporary SARIF driver names: `Semgrep` only; `Semgrep OSS` absent.
- Normalized temporary runs: `1`.
- Target rule counts:
  - `yaml.github-actions.security.run-shell-injection.run-shell-injection`: `0`
  - `yaml.github-actions.security.github-script-injection.github-script-injection`: `0`

## Restrictions and closure status
No alerts were dismissed, suppressed, or manually closed. Closure remains unconfirmed until this PR is approved and merged, a fresh default-branch upload occurs, and the resulting analysis is verified to use tool `Semgrep` with category `semgrep` and the existing analysis key.

Do not merge until Codex review and repository-owner approval are complete.