### PR TITLE
fix: resolve nanoid/brace-expansion/diff vulnerabilities in template-selector

### DIFF
--- a/PM Tools Templates - Q3 2025 Delivery Cycle/Implementation/template-selector/package-lock.json
+++ b/PM Tools Templates - Q3 2025 Delivery Cycle/Implementation/template-selector/package-lock.json
@@ -4007,16 +4007,16 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4878,12 +4878,11 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -8661,16 +8660,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/mochawesome/node_modules/diff": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
-      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8679,9 +8668,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/PM Tools Templates - Q3 2025 Delivery Cycle/Implementation/template-selector/package.json
+++ b/PM Tools Templates - Q3 2025 Delivery Cycle/Implementation/template-selector/package.json
@@ -47,7 +47,8 @@
     },
     "serialize-javascript": ">=6.0.2",
     "minimatch": ">=3.1.5",
-    "lodash": ">=4.17.22"
+    "lodash": ">=4.17.22",
+    "diff": ">=8.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",


### PR DESCRIPTION
## Description
Resolves all 4 npm-audit findings in `template-selector`:
- `nanoid` <3.3.18 (high — infinite loop with a zero-size custom generator) and `brace-expansion` 4.0.0-5.0.8 (high — DoS via unbounded expansion) resolved cleanly within existing semver ranges via `npm audit fix`.
- `diff` (jsdiff) 6.0.0-8.0.2 (low — DoS in `parsePatch`/`applyPatch`), pulled in transitively via `cypress-multi-reporters` → `mocha` → `diff`. Neither `mocha` nor `mochawesome` declare a range that resolves past 8.0.2 on their own, so I added `"diff": ">=8.0.3"` to the existing `overrides` block — following the same pattern already used there for `xlsx`/`tar-fs`/`nth-check`/etc.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Template Changes Checklist
N/A — dependency fix only.

## Governance Advisory Checklist (non-blocking)
N/A — no template/process changes.

## Testing
- [x] I have tested these changes locally
- [x] `npm audit` reports 0 vulnerabilities (was 4)
- [x] Clean install via `npm ci` succeeds (used `CYPRESS_INSTALL_BINARY=0` — the Cypress binary download itself timed out through the sandbox's network proxy, unrelated to this change)
- [x] `npm test` — 58/58 tests that load pass

## Documentation
N/A

## Additional Notes
Found but **not fixing here**, to keep this PR scoped to the vulnerability fix: 4 test suites (`TemplateSelector`, `main`, `accessibility`) fail to load with `Cannot find module 'fuse.js'`. `fuse.js` is imported in `src/hooks/useTemplates.ts` but was never added to `package.json` dependencies. Confirmed this is pre-existing on unmodified `main`, not something this change introduced. Happy to open a follow-up for it if useful.


---
_Generated by [Claude Code](https://claude.ai/code/session_011APrSZhQ8VDUnJRtmtZBVo)_