### PR TITLE
fix: bump glob/ajv to resolve vulnerabilities in dashboard-mvp

### DIFF
--- a/dashboard-mvp/package-lock.json
+++ b/dashboard-mvp/package-lock.json
@@ -4350,9 +4350,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6719,9 +6719,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {


### PR DESCRIPTION
## Description
- `glob` 10.2.0-10.4.5 (high — command injection via `-c`/`--cmd` with `shell:true`) — transitive via jest's reporters/transform/config, used only as a library for file matching here (not the vulnerable CLI path), but patched anyway. Bumped to 10.5.0.
- `ajv` <6.14.0 (moderate — ReDoS via the `$data` option) — transitive via eslint/`@eslint/eslintrc`, dev-only. Bumped to 6.15.0.

Both resolved cleanly within existing semver ranges via `npm audit fix`; no `package.json` changes needed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Template Changes Checklist
N/A — dependency fix only.

## Governance Advisory Checklist (non-blocking)
N/A — no template/process changes.

## Testing
- [x] I have tested these changes locally
- [x] `npm audit` reports 0 vulnerabilities (was 2)
- [x] `npm ci` succeeds
- [x] `npm run build` succeeds

## Documentation
N/A

## Additional Notes
`npm test` has 17/23 pre-existing failures in `dashboard-enhancements.test.tsx` (timeouts and mock issues). Confirmed identical failures on unmodified `main` by stashing this fix and re-running — unrelated to this change, not something I've touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_011APrSZhQ8VDUnJRtmtZBVo)_