### PR TITLE
Fix sensitive-information scanner execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Test sensitive-information scanner
+        run: bash tests/detect-sensitive.test.sh
       - uses: actions/setup-node@v6
         with:
           node-version: '20'

--- a/scripts/detect-sensitive.sh
+++ b/scripts/detect-sensitive.sh
@@ -4,13 +4,13 @@
 # Hard Pre-Check Gate Script for NAS Template Integration
 # Zero tolerance for names, identifiers, or PII in templates
 
-set -euo pipefail
+set -Eeuo pipefail
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMP_DIR="/tmp/pm-tools-sensitive-scan-$$"
-COMPLIANCE_REPORT="${REPO_ROOT}/meta/compliance-report-$(date +%Y%m%d-%H%M%S).md"
+COMPLIANCE_REPORT="${COMPLIANCE_REPORT:-${REPO_ROOT}/meta/compliance-report-$(date +%Y%m%d-%H%M%S).md}"
 EXIT_CODE=0
 
 # Colors for output
@@ -37,15 +37,38 @@ log_success() {
     echo -e "${GREEN}SUCCESS:${NC} $1"
 }
 
-# Create temp directory
-mkdir -p "$TEMP_DIR"
-mkdir -p "$(dirname "$COMPLIANCE_REPORT")"
-
 # Cleanup function
 cleanup() {
     rm -rf "$TEMP_DIR"
+    rm -f "${COMPLIANCE_REPORT}.tmp.$$"
 }
 trap cleanup EXIT
+
+handle_tool_error() {
+    local status=$?
+
+    trap - ERR
+    log_error "Scanner execution failed with status $status"
+    exit 2
+}
+trap handle_tool_error ERR
+
+# Create working and report directories after error handling is active.
+mkdir -p "$TEMP_DIR"
+mkdir -p "$(dirname "$COMPLIANCE_REPORT")"
+
+# Replace a report placeholder without relying on platform-specific sed -i syntax.
+replace_placeholder() {
+    local placeholder="$1"
+    local value="$2"
+    local file="$3"
+    local escaped_value
+    local temp_file="${file}.tmp.$$"
+
+    escaped_value=$(printf '%s' "$value" | sed 's/[\\&|]/\\&/g')
+    sed "s|{{$placeholder}}|$escaped_value|g" "$file" > "$temp_file"
+    mv "$temp_file" "$file"
+}
 
 # Initialize compliance report
 init_compliance_report() {
@@ -81,7 +104,7 @@ This report documents the results of the comprehensive sensitive information det
 EOF
     
     # Replace placeholders
-    sed -i '' "s/{{SCAN_DATE}}/$(date -u +"%Y-%m-%d %H:%M:%S UTC")/g" "$COMPLIANCE_REPORT"
+    replace_placeholder "SCAN_DATE" "$(date -u +"%Y-%m-%d %H:%M:%S UTC")" "$COMPLIANCE_REPORT"
 }
 
 # Email detection
@@ -106,7 +129,7 @@ detect_emails() {
         log_error "Found email addresses:"
         cat "$results_file"
         EXIT_CODE=1
-        return 1
+        return 0
     fi
     
     log_success "No email addresses detected"
@@ -136,7 +159,7 @@ detect_phones() {
         log_error "Found phone numbers:"
         cat "$results_file"
         EXIT_CODE=1
-        return 1
+        return 0
     fi
     
     log_success "No phone numbers detected"
@@ -184,7 +207,7 @@ detect_urls() {
             log_error "Found external URLs:"
             cat "$filtered_file"
             EXIT_CODE=1
-            return 1
+            return 0
         fi
     fi
     
@@ -278,7 +301,7 @@ detect_organizations() {
         log_error "Found organization references:"
         cat "$results_file"
         EXIT_CODE=1
-        return 1
+        return 0
     fi
     
     log_success "No organization references detected"
@@ -329,7 +352,7 @@ EOF
         log_error "Found deny-listed terms:"
         cat "$results_file"
         EXIT_CODE=1
-        return 1
+        return 0
     fi
     
     log_success "No deny-listed terms detected"
@@ -386,6 +409,11 @@ analyze_binary_metadata() {
 # Main scanning function
 run_detection_scan() {
     local target_dir="${1:-$REPO_ROOT}"
+
+    if [[ ! -d "$target_dir" ]]; then
+        log_error "Scan target is not a directory: $target_dir"
+        exit 2
+    fi
     
     log_info "Starting comprehensive sensitive information detection scan..."
     log_info "Target directory: $target_dir"
@@ -404,19 +432,19 @@ run_detection_scan() {
     # Generate final report
     if [[ $EXIT_CODE -eq 0 ]]; then
         log_success "✅ COMPLIANCE CHECK PASSED - No sensitive information detected"
-        sed -i '' "s/{{OVERALL_STATUS}}/✅ PASSED/g" "$COMPLIANCE_REPORT"
-        sed -i '' "s/{{SCAN_SCOPE}}/$(basename "$target_dir")/g" "$COMPLIANCE_REPORT"
-        sed -i '' "s/{{FINDINGS_SUMMARY}}/No sensitive information detected. All checks passed./g" "$COMPLIANCE_REPORT"
+        replace_placeholder "OVERALL_STATUS" "✅ PASSED" "$COMPLIANCE_REPORT"
+        replace_placeholder "SCAN_SCOPE" "$(basename "$target_dir")" "$COMPLIANCE_REPORT"
+        replace_placeholder "FINDINGS_SUMMARY" "No sensitive information detected. All checks passed." "$COMPLIANCE_REPORT"
     else
         log_error "❌ COMPLIANCE CHECK FAILED - Sensitive information detected"
-        sed -i '' "s/{{OVERALL_STATUS}}/❌ FAILED/g" "$COMPLIANCE_REPORT"
-        sed -i '' "s/{{SCAN_SCOPE}}/$(basename "$target_dir")/g" "$COMPLIANCE_REPORT"
-        sed -i '' "s/{{FINDINGS_SUMMARY}}/Sensitive information detected. Review required before proceeding./g" "$COMPLIANCE_REPORT"
+        replace_placeholder "OVERALL_STATUS" "❌ FAILED" "$COMPLIANCE_REPORT"
+        replace_placeholder "SCAN_SCOPE" "$(basename "$target_dir")" "$COMPLIANCE_REPORT"
+        replace_placeholder "FINDINGS_SUMMARY" "Sensitive information detected. Review required before proceeding." "$COMPLIANCE_REPORT"
     fi
     
     log_info "Compliance report generated: $COMPLIANCE_REPORT"
     
-    return $EXIT_CODE
+    return 0
 }
 
 # CLI handling
@@ -424,6 +452,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     case "${1:-scan}" in
         scan)
             run_detection_scan "${2:-$REPO_ROOT}"
+            exit "$EXIT_CODE"
             ;;
         help|--help|-h)
             echo "Usage: $0 [scan|help] [target_directory]"
@@ -439,7 +468,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         *)
             log_error "Unknown command: $1"
             echo "Use '$0 help' for usage information"
-            exit 1
+            exit 2
             ;;
     esac
 fi

--- a/tests/detect-sensitive.test.sh
+++ b/tests/detect-sensitive.test.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCANNER="$REPO_ROOT/scripts/detect-sensitive.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+run_scan() {
+    local expected_exit="$1"
+    local target_dir="$2"
+    local report_file="$3"
+    local output_file="$4"
+    local actual_exit
+
+    set +e
+    COMPLIANCE_REPORT="$report_file" bash "$SCANNER" scan "$target_dir" > "$output_file" 2>&1
+    actual_exit=$?
+    set -e
+
+    if [[ "$actual_exit" -ne "$expected_exit" ]]; then
+        cat "$output_file" >&2
+        echo "Expected exit $expected_exit, got $actual_exit" >&2
+        exit 1
+    fi
+}
+
+safe_dir="$TEST_ROOT/safe-fixture"
+mkdir -p "$safe_dir"
+printf 'project template\n' > "$safe_dir/template.md"
+run_scan 0 "$safe_dir" "$TEST_ROOT/safe-report.md" "$TEST_ROOT/safe-output.log"
+grep -q '\*\*Status:\*\* ✅ PASSED' "$TEST_ROOT/safe-report.md"
+grep -Eq '\*\*Scan Date:\*\* [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} UTC' "$TEST_ROOT/safe-report.md"
+if grep -q '{{SCAN_DATE}}' "$TEST_ROOT/safe-report.md"; then
+    echo 'Scan date placeholder was not replaced' >&2
+    exit 1
+fi
+grep -q 'Binary metadata analysis completed' "$TEST_ROOT/safe-output.log"
+
+sensitive_dir="$TEST_ROOT/sensitive-fixture"
+mkdir -p "$sensitive_dir"
+printf 'contact person@sensitive-test.net\n' > "$sensitive_dir/template.md"
+run_scan 1 "$sensitive_dir" "$TEST_ROOT/sensitive-report.md" "$TEST_ROOT/sensitive-output.log"
+grep -q '\*\*Status:\*\* ❌ FAILED' "$TEST_ROOT/sensitive-report.md"
+grep -q 'person@sensitive-test.net' "$TEST_ROOT/sensitive-output.log"
+grep -q 'Binary metadata analysis completed' "$TEST_ROOT/sensitive-output.log"
+
+special_dir="$TEST_ROOT/safe&scope"
+mkdir -p "$special_dir"
+printf 'project template\n' > "$special_dir/template.md"
+run_scan 0 "$special_dir" "$TEST_ROOT/special-report.md" "$TEST_ROOT/special-output.log"
+grep -q '\*\*Scan Scope:\*\* safe&scope' "$TEST_ROOT/special-report.md"
+
+mkdir "$TEST_ROOT/report-directory"
+run_scan 2 "$safe_dir" "$TEST_ROOT/report-directory" "$TEST_ROOT/tool-error-output.log"
+grep -q 'Is a directory' "$TEST_ROOT/tool-error-output.log"
+
+echo 'PASS: detect-sensitive.sh regression tests'


### PR DESCRIPTION
## Summary

Fixes #1053.

- replaces BSD-only `sed -i ''` report substitutions with portable temporary-file replacement
- preserves all existing detection patterns and allow/deny lists
- defines exit codes: `0` clean scan, `1` completed scan with findings, `2` scanner/tool/input failure
- allows all detector phases to finish after a finding so the report is complete
- adds dependency-free regression coverage and runs it in CI

## Regression coverage

`bash tests/detect-sensitive.test.sh` verifies:

- known-safe fixture exits `0`
- known-sensitive fixture exits `1`
- report/tool failure exits `2`
- UTC scan date and all report placeholders are rendered
- later scan phases still execute after a finding
- replacement safely handles `&` in the scan scope

## Validation

- `git diff --check` — PASS
- `bash -n scripts/detect-sensitive.sh tests/detect-sensitive.test.sh` — PASS
- `bash tests/detect-sensitive.test.sh` — PASS
- repository-wide scan completes and generates a report; it exits `1` for existing findings rather than failing in `sed`

## Release assurance

After CI passes, retain the workflow run, commit SHA, console log, and generated compliance report. The repository-wide findings still require disposition before release approval; an exit `2` must block assurance as an invalid scan.