### PR TITLE
fix(doc-scan): close CodeQL file-system race

### DIFF
--- a/scripts/doc-scan.js
+++ b/scripts/doc-scan.js
@@ -301,31 +301,42 @@ class DocumentScanner {
   }
 
   async scanFile(filePath) {
-    const fileStats = fs.statSync(filePath);
-    if (!fileStats.isFile()) {
+    let fd;
+    try {
+      fd = fs.openSync(filePath, 'r');
+    } catch {
       return;
     }
 
-    const content = fs.readFileSync(filePath, 'utf8');
-    const ext = path.extname(filePath);
-    
-    let scanContent = content;
-    
-    // For code files, extract comments only
-    if (!['.md', '.txt', '.adoc', '.rst'].includes(ext)) {
-      scanContent = this.extractCodeComments(content, filePath);
-      if (!scanContent.trim()) {
-        return; // No comments to scan
+    try {
+      const fileStats = fs.fstatSync(fd);
+      if (!fileStats.isFile()) {
+        return;
       }
+
+      const content = fs.readFileSync(fd, 'utf8');
+      const ext = path.extname(filePath);
+
+      let scanContent = content;
+
+      // For code files, extract comments only
+      if (!['.md', '.txt', '.adoc', '.rst'].includes(ext)) {
+        scanContent = this.extractCodeComments(content, filePath);
+        if (!scanContent.trim()) {
+          return; // No comments to scan
+        }
+      }
+
+      const securityIssues = this.scanSecurity(filePath, scanContent);
+      const relevanceIssues = this.scanRelevance(filePath, scanContent);
+
+      this.issues.push(...securityIssues, ...relevanceIssues);
+      this.stats.securityIssues += securityIssues.length;
+      this.stats.relevanceIssues += relevanceIssues.length;
+      this.stats.filesScanned++;
+    } finally {
+      fs.closeSync(fd);
     }
-    
-    const securityIssues = this.scanSecurity(filePath, scanContent);
-    const relevanceIssues = this.scanRelevance(filePath, scanContent);
-    
-    this.issues.push(...securityIssues, ...relevanceIssues);
-    this.stats.securityIssues += securityIssues.length;
-    this.stats.relevanceIssues += relevanceIssues.length;
-    this.stats.filesScanned++;
   }
 
   generateSARIF() {

--- a/scripts/doc-scan.js
+++ b/scripts/doc-scan.js
@@ -304,8 +304,11 @@ class DocumentScanner {
     let fd;
     try {
       fd = fs.openSync(filePath, 'r');
-    } catch {
-      return;
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        return;
+      }
+      throw error;
     }
 
     try {

--- a/tests/doc-scan.test.js
+++ b/tests/doc-scan.test.js
@@ -19,10 +19,11 @@ function fixture(files, setup) {
   return root;
 }
 
-function run(root) {
+function run(root, env = {}) {
   const result = spawnSync(process.execPath, [scanner], {
     cwd: root,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    env: { ...process.env, ...env }
   });
   const statsPath = path.join(root, 'scan-stats.json');
   const sarifPath = path.join(root, 'doc-scan.sarif');
@@ -31,6 +32,24 @@ function run(root) {
     stats: fs.existsSync(statsPath) ? JSON.parse(fs.readFileSync(statsPath, 'utf8')) : null,
     sarif: fs.existsSync(sarifPath) ? JSON.parse(fs.readFileSync(sarifPath, 'utf8')) : null
   };
+}
+
+function installOpenFailureHook(root, errorCode) {
+  const hook = path.join(root, 'open-failure-hook.cjs');
+  fs.writeFileSync(hook, `
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const originalOpenSync = fs.openSync;
+    fs.openSync = function(filePath, ...args) {
+      if (path.basename(String(filePath)) === 'guide.md') {
+        const error = new Error('${errorCode} test failure');
+        error.code = '${errorCode}';
+        throw error;
+      }
+      return originalOpenSync.call(this, filePath, ...args);
+    };
+  `);
+  return hook;
 }
 
 test('scans a known-safe source fixture and writes evidence', t => {
@@ -91,4 +110,27 @@ test('returns scanner-error exit for invalid scanner configuration', t => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Fatal error/);
   assert.equal(result.sarif, null);
+});
+
+test('skips a candidate that disappears before it can be opened', t => {
+  const root = fixture({ 'guide.md': '# Project management template\nSafe guidance.\n' });
+  const hook = installOpenFailureHook(root, 'ENOENT');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = run(root, { NODE_OPTIONS: `--require=${hook}` });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.equal(result.stats.filesScanned, 0);
+  assert.equal(result.stats.scanErrors, 0);
+});
+
+test('reports a non-ENOENT open failure as a scanner error', t => {
+  const root = fixture({ 'guide.md': '# Project management template\nSafe guidance.\n' });
+  const hook = installOpenFailureHook(root, 'EACCES');
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const result = run(root, { NODE_OPTIONS: `--require=${hook}` });
+  assert.equal(result.status, 1, result.stderr || result.stdout);
+  assert.equal(result.stats.filesScanned, 0);
+  assert.equal(result.stats.scanErrors, 1);
+  assert.match(result.stderr, /Error scanning guide\.md/);
 });


### PR DESCRIPTION
## Summary

- open each scan target once and retain its file descriptor
- validate the opened object with `fstatSync` before scanning
- read from that same descriptor and always close it in a `finally` block
- skip only a target that disappears between globbing and opening (`ENOENT`)
- propagate all other open failures so they increment `scanErrors` and produce scanner-error exit `1`

Closes CodeQL alert #3256 (`js/file-system-race`, CWE-367) without weakening the deterministic scanner-error contract introduced by #1072.

## Validation

- `node --check scripts/doc-scan.js` — PASS
- `node --check tests/doc-scan.test.js` — PASS
- `git diff --check` — PASS
- `npm run test:doc-scan` — 7/7 PASS

Regression coverage now proves both sides of the race behavior:

- `ENOENT` is safely skipped when a candidate disappears
- `EACCES` is logged, increments `scanErrors`, and exits `1`