### PR TITLE
Optimize visual regression scope and sharding

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'templates/**'
       - 'docs/**'
+      - 'domains/**'
+      - 'project-lifecycle/**'
+      - 'project-assessment-suite/**'
+      - 'business-stakeholder-suite/**'
+      - 'role-based-toolkits/**'
+      - 'methodology-frameworks/**'
+      - 'industry-specializations/**'
       - 'assets/**'
       - 'styles/**'
       - 'themes/**'
@@ -15,9 +22,17 @@ on:
     paths:
       - 'templates/**'
       - 'docs/**'
+      - 'domains/**'
+      - 'project-lifecycle/**'
+      - 'project-assessment-suite/**'
+      - 'business-stakeholder-suite/**'
+      - 'role-based-toolkits/**'
+      - 'methodology-frameworks/**'
+      - 'industry-specializations/**'
       - 'assets/**'
       - 'styles/**'
       - 'themes/**'
+      - '.github/workflows/visual-regression-testing.yml'
   schedule:
     # Run visual regression tests weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'
@@ -60,11 +75,15 @@ on:
 env:
   # Visual Testing Configuration
   VISUAL_DIFF_THRESHOLD: ${{ github.event.inputs.diff_threshold || '2' }}
+  GITHUB_EVENT_INPUTS_TEST_SCOPE: ${{ github.event.inputs.test_scope || 'comprehensive' }}
+  GITHUB_EVENT_INPUTS_TEST_RESOLUTION: ${{ github.event.inputs.test_resolution || 'standard' }}
+  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update || 'false' }}
   BASELINE_BRANCH: 'main'
   SCREENSHOT_TIMEOUT: 30000
   PARALLEL_WORKERS: 4
   IMAGE_QUALITY: 90
   ANIMATION_DISABLE: true
+  PLAYWRIGHT_VERSION: '1.63.0'
   
   # Browser Configuration
   CHROMIUM_VERSION: '119.0.6045.105'
@@ -100,6 +119,12 @@ jobs:
           echo "👁️ Discovering visual test targets..."
           
           mkdir -p visual-discovery
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" > visual-discovery/changed-files.txt
+          else
+            : > visual-discovery/changed-files.txt
+          fi
           
           python3 - << 'EOF'
           import os
@@ -117,8 +142,20 @@ jobs:
               template_patterns = [
                   'templates/**/*.md',
                   'templates/**/*.html',
-                  'docs/**/*.md',
-                  'docs/**/*.html'
+                  'domains/**/*.md',
+                  'domains/**/*.html',
+                  'project-lifecycle/**/*.md',
+                  'project-lifecycle/**/*.html',
+                  'project-assessment-suite/**/*.md',
+                  'project-assessment-suite/**/*.html',
+                  'business-stakeholder-suite/**/*.md',
+                  'business-stakeholder-suite/**/*.html',
+                  'role-based-toolkits/**/*.md',
+                  'role-based-toolkits/**/*.html',
+                  'methodology-frameworks/**/*.md',
+                  'methodology-frameworks/**/*.html',
+                  'industry-specializations/**/*.md',
+                  'industry-specializations/**/*.html'
               ]
               
               # Theme and style files
@@ -196,6 +233,25 @@ jobs:
               # Filter for critical-only tests
               if test_scope == 'critical-only':
                   discovered_targets = [t for t in discovered_targets if t['priority'] == 'high']
+
+              # A path may match multiple discovery categories. Keep one record per file.
+              discovered_targets = list({target['path']: target for target in discovered_targets}.values())
+
+              # Pull requests validate only changed renderable files unless shared visual
+              # assets or this workflow changed. Pushes, schedules, and manual full runs
+              # retain comprehensive repository coverage.
+              if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
+                  with open('visual-discovery/changed-files.txt', encoding='utf-8') as changed_file:
+                      changed_paths = {line.strip() for line in changed_file if line.strip()}
+                  global_visual_prefixes = ('assets/', 'styles/', 'themes/')
+                  workflow_path = '.github/workflows/visual-regression-testing.yml'
+                  requires_full_run = workflow_path in changed_paths or any(
+                      path.startswith(global_visual_prefixes) for path in changed_paths
+                  )
+                  if not requires_full_run:
+                      discovered_targets = [
+                          target for target in discovered_targets if target['path'] in changed_paths
+                      ]
               
               return discovered_targets
           
@@ -284,7 +340,7 @@ jobs:
               
               return affected[:5]  # Limit to 5 most likely affected templates
           
-          def generate_test_matrix():
+          def generate_test_matrix(target_count):
               """Generate test matrix for different resolutions and browsers"""
               resolutions = []
               test_resolution = os.environ.get('GITHUB_EVENT_INPUTS_TEST_RESOLUTION', 'standard')
@@ -323,20 +379,25 @@ jobs:
               # browsers = ['chromium', 'firefox', 'webkit']
               
               matrix = []
+              # Keep small PRs cheap; shard comprehensive or large runs.
+              shard_count = 1 if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request' and target_count <= 25 else 4
               for resolution in resolutions:
                   for browser in browsers:
-                      matrix.append({
-                          'browser': browser,
-                          'resolution': resolution,
-                          'identifier': f"{browser}_{resolution['name']}"
-                      })
+                      for shard_index in range(shard_count):
+                          matrix.append({
+                              'browser': browser,
+                              'resolution': resolution,
+                              'identifier': f"{browser}_{resolution['name']}_shard_{shard_index + 1}_of_{shard_count}",
+                              'shard_index': shard_index,
+                              'shard_total': shard_count
+                          })
               
               return matrix
           
           # Main discovery process
           print("Discovering visual test targets...")
           targets = discover_visual_targets()
-          test_matrix = generate_test_matrix()
+          test_matrix = generate_test_matrix(len(targets))
           
           # Check if baselines exist
           baseline_exists = os.path.exists('.github/visual-baselines') or os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
@@ -407,6 +468,7 @@ jobs:
   template-rendering:
     name: 📄 Template Rendering
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: visual-discovery
     if: needs.visual-discovery.outputs.total_tests > 0
     
@@ -423,19 +485,7 @@ jobs:
       - name: 🛠️ Setup Rendering Environment
         run: |
           echo "🛠️ Setting up template rendering environment..."
-          
-          # Install Node.js for static site generators
-          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-          sudo apt-get install -y nodejs
-          
-          # Install Python for markdown processing
-          pip install markdown jinja2 pyyaml python-frontmatter
-          
-          # Install common static site generators
-          npm install -g @11ty/eleventy markdown-it live-server
-          
-          # Install pandoc for document conversion
-          sudo apt-get install -y pandoc
+          python3 -m pip install markdown pyyaml python-frontmatter
           
           echo "✅ Rendering environment ready"
 
@@ -515,7 +565,9 @@ jobs:
           </html>"""
                   
                   # Save rendered HTML
-                  output_file = Path(output_dir) / f"{Path(md_path).stem}.html"
+                  path_key = str(Path(md_path)).replace('\\', '/')
+                  digest = __import__('hashlib').sha256(path_key.encode('utf-8')).hexdigest()[:12]
+                  output_file = Path(output_dir) / f"{Path(md_path).stem}-{digest}.html"
                   output_file.parent.mkdir(parents=True, exist_ok=True)
                   
                   with open(output_file, 'w', encoding='utf-8') as f:
@@ -670,7 +722,9 @@ jobs:
               elif target['path'].endswith('.html'):
                   # Copy HTML files as-is
                   import shutil
-                  output_file = f"rendered-templates/{Path(target['path']).name}"
+                  path_key = str(Path(target['path'])).replace('\\', '/')
+                  digest = __import__('hashlib').sha256(path_key.encode('utf-8')).hexdigest()[:12]
+                  output_file = f"rendered-templates/{Path(target['path']).stem}-{digest}{Path(target['path']).suffix}"
                   shutil.copy2(target['path'], output_file)
                   rendered_files.append({
                       'original': target['path'],
@@ -696,18 +750,15 @@ jobs:
 
   # Visual Screenshot Capture
   visual-capture:
-    name: 📸 Visual Capture
+    name: 📸 Visual Capture (${{ matrix.identifier }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [visual-discovery, template-rendering]
     if: needs.visual-discovery.outputs.total_tests > 0
     
     strategy:
       matrix:
-        browser: [chromium]
-        resolution: [
-          { width: 375, height: 667, name: 'mobile' },
-          { width: 1366, height: 768, name: 'desktop' }
-        ]
+        include: ${{ fromJSON(needs.visual-discovery.outputs.test_matrix) }}
       fail-fast: false
     
     steps:
@@ -721,10 +772,16 @@ jobs:
           path: rendered-templates/
 
       - name: 🛠️ Setup Playwright
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: 🛠️ Install Playwright
         run: |
           echo "🛠️ Setting up Playwright for visual capture..."
           
-          npm install playwright
+          npm install --no-save "playwright@${PLAYWRIGHT_VERSION}"
           npx playwright install chromium
           npx playwright install-deps chromium
           
@@ -738,12 +795,16 @@ jobs:
           
           node - << 'EOF'
           const { chromium } = require('playwright');
+          const crypto = require('crypto');
           const fs = require('fs');
           const path = require('path');
           
           (async () => {
               // Load rendered files manifest
-              const manifest = JSON.parse(fs.readFileSync('rendered-templates/manifest.json', 'utf8'));
+              const fullManifest = JSON.parse(fs.readFileSync('rendered-templates/manifest.json', 'utf8'));
+              const shardIndex = Number('${{ matrix.shard_index }}');
+              const shardTotal = Number('${{ matrix.shard_total }}');
+              const manifest = fullManifest.filter((_, index) => index % shardTotal === shardIndex);
               
               // Launch browser
               const browser = await chromium.launch({
@@ -761,19 +822,8 @@ jobs:
               
               const page = await context.newPage();
               
-              // Disable animations for consistent screenshots
-              await page.addStyleTag({
-                  content: `
-                      *, *::before, *::after {
-                          animation-duration: 0s !important;
-                          animation-delay: 0s !important;
-                          transition-duration: 0s !important;
-                          transition-delay: 0s !important;
-                      }
-                  `
-              });
-              
               console.log(`Starting screenshot capture for ${manifest.length} files...`);
+              let captureFailures = 0;
               
               for (const file of manifest) {
                   try {
@@ -783,23 +833,44 @@ jobs:
                       console.log(`Capturing: ${file.original}`);
                       
                       // Navigate to the file
-                      await page.goto(fileUrl, { 
-                          waitUntil: 'networkidle',
+                      await page.goto(fileUrl, {
+                          waitUntil: 'domcontentloaded',
                           timeout: parseInt(process.env.SCREENSHOT_TIMEOUT || '30000')
                       });
-                      
-                      // Wait for content to load
-                      await page.waitForLoadState('domcontentloaded');
-                      await page.waitForTimeout(1000); // Additional wait for rendering
+
+                      await page.addStyleTag({
+                          content: `
+                              *, *::before, *::after {
+                                  animation-duration: 0s !important;
+                                  animation-delay: 0s !important;
+                                  transition-duration: 0s !important;
+                                  transition-delay: 0s !important;
+                              }
+                          `
+                      });
+
+                      // Wait only for render-affecting local resources rather than an
+                      // unconditional delay for every screenshot.
+                      await page.evaluate(async () => {
+                          if (document.fonts?.ready) await document.fonts.ready;
+                          await Promise.all(Array.from(document.images).map(image => {
+                              if (image.complete) return Promise.resolve();
+                              return new Promise(resolve => {
+                                  image.addEventListener('load', resolve, { once: true });
+                                  image.addEventListener('error', resolve, { once: true });
+                              });
+                          }));
+                      });
                       
                       // Take screenshot
-                      const screenshotName = `${path.basename(file.original, path.extname(file.original))}.png`;
+                      const sourceKey = file.original.replace(/\\/g, '/');
+                      const sourceHash = crypto.createHash('sha256').update(sourceKey).digest('hex').slice(0, 12);
+                      const screenshotName = `${path.basename(file.original, path.extname(file.original))}-${sourceHash}.png`;
                       const screenshotPath = `screenshots/${{ matrix.browser }}_${{ matrix.resolution.name }}/${screenshotName}`;
                       
                       await page.screenshot({
                           path: screenshotPath,
-                          fullPage: true,
-                          quality: parseInt(process.env.IMAGE_QUALITY || '90')
+                          fullPage: true
                       });
                       
                       console.log(`  ✅ Screenshot saved: ${screenshotPath}`);
@@ -837,15 +908,16 @@ jobs:
                                   `
                               });
                               
-                              await page.waitForTimeout(500);
+                              await page.evaluate(() => new Promise(resolve =>
+                                  requestAnimationFrame(() => requestAnimationFrame(resolve))
+                              ));
                               
-                              const darkScreenshotName = `${path.basename(file.original, path.extname(file.original))}_dark.png`;
+                              const darkScreenshotName = `${path.basename(file.original, path.extname(file.original))}-${sourceHash}_dark.png`;
                               const darkScreenshotPath = `screenshots/${{ matrix.browser }}_${{ matrix.resolution.name }}/${darkScreenshotName}`;
                               
                               await page.screenshot({
                                   path: darkScreenshotPath,
-                                  fullPage: true,
-                                  quality: parseInt(process.env.IMAGE_QUALITY || '90')
+                                  fullPage: true
                               });
                               
                               console.log(`  🌙 Dark theme screenshot: ${darkScreenshotPath}`);
@@ -853,11 +925,15 @@ jobs:
                       }
                       
                   } catch (error) {
+                      captureFailures += 1;
                       console.error(`❌ Error capturing ${file.original}:`, error.message);
                   }
               }
               
               await browser.close();
+              if (captureFailures > 0) {
+                  throw new Error(`${captureFailures} screenshot capture(s) failed`);
+              }
               console.log('Screenshot capture completed!');
           })();
           EOF
@@ -866,7 +942,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: screenshots-${{ matrix.browser }}-${{ matrix.resolution.name }}-${{ github.run_number }}
+          name: screenshots-${{ matrix.browser }}-${{ matrix.resolution.name }}-shard-${{ matrix.shard_index }}-${{ github.run_number }}
           path: screenshots/
           retention-days: 30
 
@@ -874,6 +950,7 @@ jobs:
   visual-comparison:
     name: 🔍 Visual Comparison
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [visual-discovery, visual-capture]
     if: always() && needs.visual-discovery.outputs.total_tests > 0
     

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -197,7 +197,9 @@ jobs:
               
               # Discover documentation
               if test_scope in ['comprehensive', 'docs-only']:
-                  doc_files = glob.glob('docs/**/*.md', recursive=True)
+                  doc_files = []
+                  for pattern in ['docs/**/*.md', 'docs/**/*.html']:
+                      doc_files.extend(glob.glob(pattern, recursive=True))
                   for doc_path in doc_files:
                       if os.path.exists(doc_path):
                           target = {


### PR DESCRIPTION
## Summary

Improves the visual regression workflow so future pull requests run the smallest relevant test set while preserving comprehensive coverage on main, scheduled, and manual runs.

## Changes

- scopes pull-request captures to changed renderable files
- falls back to the full suite when shared visual infrastructure changes
- deduplicates discovery and includes the migrated domain/template roots
- prevents rendered-file and screenshot collisions with path-derived hashes
- uses adaptive sharding: one shard for small PRs, four for larger/full runs
- replaces fixed waits with DOM, font, and image readiness checks
- caches the pinned Playwright browser installation
- removes unused rendering dependencies
- adds job timeouts and makes capture failures fail the job
- fixes post-navigation animation suppression and invalid PNG screenshot options

## Expected performance

- A one-file documentation or template PR: 1 target, 2 capture jobs (desktop + mobile)
- Comprehensive run: 692 unique targets, split across 4 shards per viewport
- Removes roughly 30.6 minutes of aggregate fixed sleep time from the former full suite

## Validation

- `git diff --check`
- workflow YAML parsed successfully (5 jobs)
- embedded capture JavaScript passed syntax validation
- comprehensive discovery simulation found 692 unique targets and an 8-job capture matrix
- path hashing eliminated basename output collisions

## Rollback

Revert commit `938fcfe10efc12510c977f6ea3082d1819b6ccb7` to restore the previous workflow.

## Governance references

- `docs/governance/task-closure-checklist.md`
- `docs/governance/rollback-plan-template.md`
- `docs/governance/security-compliance-checklist.md`
- `docs/governance/lessons-learned-template.md`

Related to #1057. This PR does not close the migration issue.

## Known follow-up

The repository currently has no committed image baselines, so this change improves capture performance and correctness but does not by itself establish true pixel-diff regression coverage. Baseline creation and review should remain a separate, explicitly approved change.