### PR TITLE
Implement reviewed visual regression baselines

### DIFF
--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -1070,46 +1070,43 @@ jobs:
                       or max_tile_diff_percentage > tile_threshold_percent
                   )
                   
-                  # Create visual diff image
-                  diff_image = Image.fromarray(diff_array.astype(np.uint8))
-                  
-                  # Enhance diff visibility
-                  diff_enhanced = diff_image.point(lambda x: min(255, x * 3))
-                  
-                  # Create side-by-side comparison
-                  width, height = baseline.size
-                  comparison = Image.new('RGB', (width * 3, height + 50), 'white')
-                  
-                  # Paste images
-                  comparison.paste(baseline, (0, 50))
-                  comparison.paste(current, (width, 50))
-                  comparison.paste(diff_enhanced, (width * 2, 50))
-                  
-                  # Add labels
-                  draw = ImageDraw.Draw(comparison)
-                  try:
-                      font = ImageFont.truetype("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf", 16)
-                  except:
-                      font = ImageFont.load_default()
-                  
-                  draw.text((10, 10), "BASELINE", fill='black', font=font)
-                  draw.text((width + 10, 10), "CURRENT", fill='black', font=font)
-                  draw.text(
-                      (width * 2 + 10, 10),
-                      f"DIFF ({diff_percentage:.2f}% / tile {max_tile_diff_percentage:.2f}%)",
-                      fill='red' if threshold_exceeded else 'green',
-                      font=font
-                  )
-                  
-                  # Save comparison
-                  comparison.save(diff_path)
+                  # Passing comparisons are fully represented in JSON. Generate
+                  # the heavier side-by-side image only when review is required.
+                  if threshold_exceeded:
+                      diff_image = Image.fromarray(diff_array.astype(np.uint8))
+                      diff_enhanced = diff_image.point(lambda x: min(255, x * 3))
+
+                      width, height = baseline.size
+                      comparison = Image.new('RGB', (width * 3, height + 50), 'white')
+                      comparison.paste(baseline, (0, 50))
+                      comparison.paste(current, (width, 50))
+                      comparison.paste(diff_enhanced, (width * 2, 50))
+
+                      draw = ImageDraw.Draw(comparison)
+                      try:
+                          font = ImageFont.truetype(
+                              "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+                              16
+                          )
+                      except OSError:
+                          font = ImageFont.load_default()
+
+                      draw.text((10, 10), "BASELINE", fill='black', font=font)
+                      draw.text((width + 10, 10), "CURRENT", fill='black', font=font)
+                      draw.text(
+                          (width * 2 + 10, 10),
+                          f"DIFF ({diff_percentage:.2f}% / tile {max_tile_diff_percentage:.2f}%)",
+                          fill='red',
+                          font=font
+                      )
+                      comparison.save(diff_path)
                   
                   return {
                       'diff_percentage': round(diff_percentage, 2),
                       'max_tile_diff_percentage': round(max_tile_diff_percentage, 2),
                       'total_pixels': int(total_pixels),
                       'threshold_exceeded': threshold_exceeded,
-                      'diff_image': diff_path
+                      'diff_image': diff_path if threshold_exceeded else None
                   }
                   
               except Exception as e:

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -81,7 +81,7 @@ env:
   GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update == 'true' }}
   BASELINE_BRANCH: 'visual-baselines'
   SCREENSHOT_TIMEOUT: 30000
-  PARALLEL_WORKERS: 4
+  PARALLEL_WORKERS: 2
   IMAGE_QUALITY: 90
   ANIMATION_DISABLE: true
   PLAYWRIGHT_VERSION: '1.63.0'
@@ -1022,6 +1022,7 @@ jobs:
           import os
           import json
           import glob
+          from concurrent.futures import ThreadPoolExecutor
           from pathlib import Path
           from PIL import Image, ImageDraw, ImageFont
           import numpy as np
@@ -1166,8 +1167,7 @@ jobs:
           print(f"Found baseline sets: {list(baseline_screenshots.keys())}")
           
           comparison_results = []
-          total_comparisons = 0
-          regressions_found = 0
+          comparison_tasks = []
           
           for browser_resolution, current_files in current_screenshots.items():
               print(f"\nProcessing {browser_resolution}...")
@@ -1189,31 +1189,50 @@ jobs:
                   }
                   
                   if baseline_file and os.path.exists(baseline_file):
-                      # Perform comparison
                       diff_path = f"visual-comparison-results/{browser_resolution}_{filename.replace('.png', '_diff.png')}"
-                      os.makedirs(os.path.dirname(diff_path), exist_ok=True)
-                      
-                      comparison = compare_images(
+                      comparison_tasks.append((
+                          result,
                           current_file,
                           baseline_file,
-                          diff_path,
-                          threshold_percent,
-                          tile_threshold_percent
-                      )
-                      result.update(comparison)
-                      
-                      total_comparisons += 1
-                      if comparison.get('threshold_exceeded', False):
-                          regressions_found += 1
-                          print(f"  🚨 REGRESSION: {filename} - {comparison.get('diff_percentage', 0)}% difference")
-                      else:
-                          print(f"  ✅ PASS: {filename} - {comparison.get('diff_percentage', 0)}% difference")
+                          diff_path
+                      ))
                   
                   else:
                       print(f"  📷 NEW: {filename} - no baseline available")
                       result['status'] = 'new_screenshot'
                   
-                  comparison_results.append(result)
+                      comparison_results.append(result)
+
+          def execute_comparison(task):
+              result, current_file, baseline_file, diff_path = task
+              comparison = compare_images(
+                  current_file,
+                  baseline_file,
+                  diff_path,
+                  threshold_percent,
+                  tile_threshold_percent
+              )
+              result.update(comparison)
+              return result
+
+          worker_count = max(1, int(os.environ.get('PARALLEL_WORKERS', '2')))
+          print(f"Comparing {len(comparison_tasks)} screenshots with {worker_count} workers...")
+          with ThreadPoolExecutor(max_workers=worker_count) as executor:
+              compared_results = list(executor.map(execute_comparison, comparison_tasks))
+          comparison_results.extend(compared_results)
+
+          total_comparisons = len(compared_results)
+          regressions = [
+              result for result in compared_results
+              if result.get('threshold_exceeded', False)
+          ]
+          regressions_found = len(regressions)
+          for result in regressions:
+              print(
+                  f"  🚨 REGRESSION: {result['filename']} - "
+                  f"{result.get('diff_percentage', 0)}% global / "
+                  f"{result.get('max_tile_diff_percentage', 0)}% tile"
+              )
           
           # Generate summary
           summary = {

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - 'templates/**'
       - 'docs/**'
+      - 'domains/**'
+      - 'project-lifecycle/**'
+      - 'project-assessment-suite/**'
+      - 'business-stakeholder-suite/**'
+      - 'role-based-toolkits/**'
+      - 'methodology-frameworks/**'
+      - 'industry-specializations/**'
       - 'assets/**'
       - 'styles/**'
       - 'themes/**'
@@ -15,9 +22,17 @@ on:
     paths:
       - 'templates/**'
       - 'docs/**'
+      - 'domains/**'
+      - 'project-lifecycle/**'
+      - 'project-assessment-suite/**'
+      - 'business-stakeholder-suite/**'
+      - 'role-based-toolkits/**'
+      - 'methodology-frameworks/**'
+      - 'industry-specializations/**'
       - 'assets/**'
       - 'styles/**'
       - 'themes/**'
+      - '.github/workflows/visual-regression-testing.yml'
   schedule:
     # Run visual regression tests weekly on Sundays at 2 AM UTC
     - cron: '0 2 * * 0'
@@ -60,11 +75,15 @@ on:
 env:
   # Visual Testing Configuration
   VISUAL_DIFF_THRESHOLD: ${{ github.event.inputs.diff_threshold || '2' }}
+  GITHUB_EVENT_INPUTS_TEST_SCOPE: ${{ github.event.inputs.test_scope || 'comprehensive' }}
+  GITHUB_EVENT_INPUTS_TEST_RESOLUTION: ${{ github.event.inputs.test_resolution || 'standard' }}
+  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update || 'false' }}
   BASELINE_BRANCH: 'main'
   SCREENSHOT_TIMEOUT: 30000
   PARALLEL_WORKERS: 4
   IMAGE_QUALITY: 90
   ANIMATION_DISABLE: true
+  PLAYWRIGHT_VERSION: '1.63.0'
   
   # Browser Configuration
   CHROMIUM_VERSION: '119.0.6045.105'
@@ -100,6 +119,12 @@ jobs:
           echo "👁️ Discovering visual test targets..."
           
           mkdir -p visual-discovery
+
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only --diff-filter=ACMR "origin/${GITHUB_BASE_REF}...HEAD" > visual-discovery/changed-files.txt
+          else
+            : > visual-discovery/changed-files.txt
+          fi
           
           python3 - << 'EOF'
           import os
@@ -117,8 +142,20 @@ jobs:
               template_patterns = [
                   'templates/**/*.md',
                   'templates/**/*.html',
-                  'docs/**/*.md',
-                  'docs/**/*.html'
+                  'domains/**/*.md',
+                  'domains/**/*.html',
+                  'project-lifecycle/**/*.md',
+                  'project-lifecycle/**/*.html',
+                  'project-assessment-suite/**/*.md',
+                  'project-assessment-suite/**/*.html',
+                  'business-stakeholder-suite/**/*.md',
+                  'business-stakeholder-suite/**/*.html',
+                  'role-based-toolkits/**/*.md',
+                  'role-based-toolkits/**/*.html',
+                  'methodology-frameworks/**/*.md',
+                  'methodology-frameworks/**/*.html',
+                  'industry-specializations/**/*.md',
+                  'industry-specializations/**/*.html'
               ]
               
               # Theme and style files
@@ -196,6 +233,25 @@ jobs:
               # Filter for critical-only tests
               if test_scope == 'critical-only':
                   discovered_targets = [t for t in discovered_targets if t['priority'] == 'high']
+
+              # A path may match multiple discovery categories. Keep one record per file.
+              discovered_targets = list({target['path']: target for target in discovered_targets}.values())
+
+              # Pull requests validate only changed renderable files unless shared visual
+              # assets or this workflow changed. Pushes, schedules, and manual full runs
+              # retain comprehensive repository coverage.
+              if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request':
+                  with open('visual-discovery/changed-files.txt', encoding='utf-8') as changed_file:
+                      changed_paths = {line.strip() for line in changed_file if line.strip()}
+                  global_visual_prefixes = ('assets/', 'styles/', 'themes/')
+                  workflow_path = '.github/workflows/visual-regression-testing.yml'
+                  requires_full_run = workflow_path in changed_paths or any(
+                      path.startswith(global_visual_prefixes) for path in changed_paths
+                  )
+                  if not requires_full_run:
+                      discovered_targets = [
+                          target for target in discovered_targets if target['path'] in changed_paths
+                      ]
               
               return discovered_targets
           
@@ -284,7 +340,7 @@ jobs:
               
               return affected[:5]  # Limit to 5 most likely affected templates
           
-          def generate_test_matrix():
+          def generate_test_matrix(target_count):
               """Generate test matrix for different resolutions and browsers"""
               resolutions = []
               test_resolution = os.environ.get('GITHUB_EVENT_INPUTS_TEST_RESOLUTION', 'standard')
@@ -323,20 +379,25 @@ jobs:
               # browsers = ['chromium', 'firefox', 'webkit']
               
               matrix = []
+              # Keep small PRs cheap; shard comprehensive or large runs.
+              shard_count = 1 if os.environ.get('GITHUB_EVENT_NAME') == 'pull_request' and target_count <= 25 else 4
               for resolution in resolutions:
                   for browser in browsers:
-                      matrix.append({
-                          'browser': browser,
-                          'resolution': resolution,
-                          'identifier': f"{browser}_{resolution['name']}"
-                      })
+                      for shard_index in range(shard_count):
+                          matrix.append({
+                              'browser': browser,
+                              'resolution': resolution,
+                              'identifier': f"{browser}_{resolution['name']}_shard_{shard_index + 1}_of_{shard_count}",
+                              'shard_index': shard_index,
+                              'shard_total': shard_count
+                          })
               
               return matrix
           
           # Main discovery process
           print("Discovering visual test targets...")
           targets = discover_visual_targets()
-          test_matrix = generate_test_matrix()
+          test_matrix = generate_test_matrix(len(targets))
           
           # Check if baselines exist
           baseline_exists = os.path.exists('.github/visual-baselines') or os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
@@ -407,6 +468,7 @@ jobs:
   template-rendering:
     name: 📄 Template Rendering
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: visual-discovery
     if: needs.visual-discovery.outputs.total_tests > 0
     
@@ -423,19 +485,7 @@ jobs:
       - name: 🛠️ Setup Rendering Environment
         run: |
           echo "🛠️ Setting up template rendering environment..."
-          
-          # Install Node.js for static site generators
-          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-          sudo apt-get install -y nodejs
-          
-          # Install Python for markdown processing
-          pip install markdown jinja2 pyyaml python-frontmatter
-          
-          # Install common static site generators
-          npm install -g @11ty/eleventy markdown-it live-server
-          
-          # Install pandoc for document conversion
-          sudo apt-get install -y pandoc
+          python3 -m pip install markdown pyyaml python-frontmatter
           
           echo "✅ Rendering environment ready"
 
@@ -515,7 +565,9 @@ jobs:
           </html>"""
                   
                   # Save rendered HTML
-                  output_file = Path(output_dir) / f"{Path(md_path).stem}.html"
+                  path_key = str(Path(md_path)).replace('\\', '/')
+                  digest = __import__('hashlib').sha256(path_key.encode('utf-8')).hexdigest()[:12]
+                  output_file = Path(output_dir) / f"{Path(md_path).stem}-{digest}.html"
                   output_file.parent.mkdir(parents=True, exist_ok=True)
                   
                   with open(output_file, 'w', encoding='utf-8') as f:
@@ -670,7 +722,9 @@ jobs:
               elif target['path'].endswith('.html'):
                   # Copy HTML files as-is
                   import shutil
-                  output_file = f"rendered-templates/{Path(target['path']).name}"
+                  path_key = str(Path(target['path'])).replace('\\', '/')
+                  digest = __import__('hashlib').sha256(path_key.encode('utf-8')).hexdigest()[:12]
+                  output_file = f"rendered-templates/{Path(target['path']).stem}-{digest}{Path(target['path']).suffix}"
                   shutil.copy2(target['path'], output_file)
                   rendered_files.append({
                       'original': target['path'],
@@ -696,18 +750,15 @@ jobs:
 
   # Visual Screenshot Capture
   visual-capture:
-    name: 📸 Visual Capture
+    name: 📸 Visual Capture (${{ matrix.identifier }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [visual-discovery, template-rendering]
     if: needs.visual-discovery.outputs.total_tests > 0
     
     strategy:
       matrix:
-        browser: [chromium]
-        resolution: [
-          { width: 375, height: 667, name: 'mobile' },
-          { width: 1366, height: 768, name: 'desktop' }
-        ]
+        include: ${{ fromJSON(needs.visual-discovery.outputs.test_matrix) }}
       fail-fast: false
     
     steps:
@@ -721,10 +772,16 @@ jobs:
           path: rendered-templates/
 
       - name: 🛠️ Setup Playwright
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+
+      - name: 🛠️ Install Playwright
         run: |
           echo "🛠️ Setting up Playwright for visual capture..."
           
-          npm install playwright
+          npm install --no-save "playwright@${PLAYWRIGHT_VERSION}"
           npx playwright install chromium
           npx playwright install-deps chromium
           
@@ -738,12 +795,16 @@ jobs:
           
           node - << 'EOF'
           const { chromium } = require('playwright');
+          const crypto = require('crypto');
           const fs = require('fs');
           const path = require('path');
           
           (async () => {
               // Load rendered files manifest
-              const manifest = JSON.parse(fs.readFileSync('rendered-templates/manifest.json', 'utf8'));
+              const fullManifest = JSON.parse(fs.readFileSync('rendered-templates/manifest.json', 'utf8'));
+              const shardIndex = Number('${{ matrix.shard_index }}');
+              const shardTotal = Number('${{ matrix.shard_total }}');
+              const manifest = fullManifest.filter((_, index) => index % shardTotal === shardIndex);
               
               // Launch browser
               const browser = await chromium.launch({
@@ -761,19 +822,8 @@ jobs:
               
               const page = await context.newPage();
               
-              // Disable animations for consistent screenshots
-              await page.addStyleTag({
-                  content: `
-                      *, *::before, *::after {
-                          animation-duration: 0s !important;
-                          animation-delay: 0s !important;
-                          transition-duration: 0s !important;
-                          transition-delay: 0s !important;
-                      }
-                  `
-              });
-              
               console.log(`Starting screenshot capture for ${manifest.length} files...`);
+              let captureFailures = 0;
               
               for (const file of manifest) {
                   try {
@@ -783,23 +833,44 @@ jobs:
                       console.log(`Capturing: ${file.original}`);
                       
                       // Navigate to the file
-                      await page.goto(fileUrl, { 
-                          waitUntil: 'networkidle',
+                      await page.goto(fileUrl, {
+                          waitUntil: 'domcontentloaded',
                           timeout: parseInt(process.env.SCREENSHOT_TIMEOUT || '30000')
                       });
-                      
-                      // Wait for content to load
-                      await page.waitForLoadState('domcontentloaded');
-                      await page.waitForTimeout(1000); // Additional wait for rendering
+
+                      await page.addStyleTag({
+                          content: `
+                              *, *::before, *::after {
+                                  animation-duration: 0s !important;
+                                  animation-delay: 0s !important;
+                                  transition-duration: 0s !important;
+                                  transition-delay: 0s !important;
+                              }
+                          `
+                      });
+
+                      // Wait only for render-affecting local resources rather than an
+                      // unconditional delay for every screenshot.
+                      await page.evaluate(async () => {
+                          if (document.fonts?.ready) await document.fonts.ready;
+                          await Promise.all(Array.from(document.images).map(image => {
+                              if (image.complete) return Promise.resolve();
+                              return new Promise(resolve => {
+                                  image.addEventListener('load', resolve, { once: true });
+                                  image.addEventListener('error', resolve, { once: true });
+                              });
+                          }));
+                      });
                       
                       // Take screenshot
-                      const screenshotName = `${path.basename(file.original, path.extname(file.original))}.png`;
+                      const sourceKey = file.original.replace(/\\/g, '/');
+                      const sourceHash = crypto.createHash('sha256').update(sourceKey).digest('hex').slice(0, 12);
+                      const screenshotName = `${path.basename(file.original, path.extname(file.original))}-${sourceHash}.png`;
                       const screenshotPath = `screenshots/${{ matrix.browser }}_${{ matrix.resolution.name }}/${screenshotName}`;
                       
                       await page.screenshot({
                           path: screenshotPath,
-                          fullPage: true,
-                          quality: parseInt(process.env.IMAGE_QUALITY || '90')
+                          fullPage: true
                       });
                       
                       console.log(`  ✅ Screenshot saved: ${screenshotPath}`);
@@ -837,15 +908,16 @@ jobs:
                                   `
                               });
                               
-                              await page.waitForTimeout(500);
+                              await page.evaluate(() => new Promise(resolve =>
+                                  requestAnimationFrame(() => requestAnimationFrame(resolve))
+                              ));
                               
-                              const darkScreenshotName = `${path.basename(file.original, path.extname(file.original))}_dark.png`;
+                              const darkScreenshotName = `${path.basename(file.original, path.extname(file.original))}-${sourceHash}_dark.png`;
                               const darkScreenshotPath = `screenshots/${{ matrix.browser }}_${{ matrix.resolution.name }}/${darkScreenshotName}`;
                               
                               await page.screenshot({
                                   path: darkScreenshotPath,
-                                  fullPage: true,
-                                  quality: parseInt(process.env.IMAGE_QUALITY || '90')
+                                  fullPage: true
                               });
                               
                               console.log(`  🌙 Dark theme screenshot: ${darkScreenshotPath}`);
@@ -853,11 +925,15 @@ jobs:
                       }
                       
                   } catch (error) {
+                      captureFailures += 1;
                       console.error(`❌ Error capturing ${file.original}:`, error.message);
                   }
               }
               
               await browser.close();
+              if (captureFailures > 0) {
+                  throw new Error(`${captureFailures} screenshot capture(s) failed`);
+              }
               console.log('Screenshot capture completed!');
           })();
           EOF
@@ -866,7 +942,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: screenshots-${{ matrix.browser }}-${{ matrix.resolution.name }}-${{ github.run_number }}
+          name: screenshots-${{ matrix.browser }}-${{ matrix.resolution.name }}-shard-${{ matrix.shard_index }}-${{ github.run_number }}
           path: screenshots/
           retention-days: 30
 
@@ -874,6 +950,7 @@ jobs:
   visual-comparison:
     name: 🔍 Visual Comparison
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [visual-discovery, visual-capture]
     if: always() && needs.visual-discovery.outputs.total_tests > 0
     

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -78,9 +78,7 @@ env:
   VISUAL_TILE_DIFF_THRESHOLD: '3'
   GITHUB_EVENT_INPUTS_TEST_SCOPE: ${{ github.event.inputs.test_scope || 'comprehensive' }}
   GITHUB_EVENT_INPUTS_TEST_RESOLUTION: ${{ github.event.inputs.test_resolution || 'standard' }}
-  # The PR-head clause is a one-time bootstrap and is removed after the first
-  # reviewed baseline is published.
-  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update == 'true' || (github.event_name == 'pull_request' && github.head_ref == 'feat/visual-regression-baselines') }}
+  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update == 'true' }}
   BASELINE_BRANCH: 'visual-baselines'
   SCREENSHOT_TIMEOUT: 30000
   PARALLEL_WORKERS: 4
@@ -967,7 +965,7 @@ jobs:
   visual-comparison:
     name: 🔍 Visual Comparison
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     needs: [visual-discovery, visual-capture]
     if: always() && needs.visual-discovery.outputs.total_tests > 0
     
@@ -1028,7 +1026,6 @@ jobs:
           from PIL import Image, ImageDraw, ImageFont
           import numpy as np
           from datetime import datetime
-          import shutil
           
           def compare_images(
               current_path,
@@ -1254,37 +1251,6 @@ jobs:
           with open('visual-comparison-results/summary.json', 'w') as f:
               json.dump(summary, f, indent=2)
           
-          # Update baselines if requested
-          if update_baseline:
-              print("\n📤 Updating visual baselines...")
-              baseline_dir = '.github/visual-baselines'
-              
-              # Remove old baselines
-              if os.path.exists(baseline_dir):
-                  shutil.rmtree(baseline_dir)
-              
-              # Copy current screenshots as new baselines
-              for browser_resolution, files in current_screenshots.items():
-                  target_dir = f"{baseline_dir}/screenshots-{browser_resolution}"
-                  os.makedirs(target_dir, exist_ok=True)
-                  
-                  for file_path in files:
-                      filename = os.path.basename(file_path)
-                      target_path = f"{target_dir}/{Path(filename).stem}.webp"
-                      with Image.open(file_path).convert('RGB') as image:
-                          width, height = image.size
-                          baseline_width = 256
-                          scale = min(baseline_width / width, 16383 / height)
-                          baseline_width = max(1, round(width * scale))
-                          baseline_height = max(1, round(height * scale))
-                          image = image.resize(
-                              (baseline_width, baseline_height), Image.Resampling.LANCZOS
-                          )
-                          image.save(target_path, 'WEBP', quality=85, method=4)
-                      print(f"    ✅ Updated baseline: {filename}")
-              
-              print("✅ Baseline update completed!")
-          
           # Set exit code based on regressions
           if regressions_found > 0 and not update_baseline:
               print(f"\n🚨 {regressions_found} visual regressions detected!")
@@ -1301,20 +1267,12 @@ jobs:
           path: visual-comparison-results/
           retention-days: 30
 
-      - name: 📤 Update Visual Baselines
-        if: env.GITHUB_EVENT_INPUTS_BASELINE_UPDATE == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: visual-baselines-${{ github.run_number }}
-          path: .github/visual-baselines/
-          retention-days: 90
-
   visual-baseline-publish:
     name: 📌 Publish Reviewed Visual Baselines
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [visual-discovery, visual-capture, visual-comparison]
-    if: (github.event.inputs.baseline_update == 'true' || (github.event_name == 'pull_request' && github.head_ref == 'feat/visual-regression-baselines')) && needs.visual-capture.result == 'success' && needs.visual-comparison.result == 'success'
+    if: github.event.inputs.baseline_update == 'true' && needs.visual-capture.result == 'success' && needs.visual-comparison.result == 'success'
     permissions:
       contents: write
 
@@ -1364,7 +1322,7 @@ jobs:
             git switch --orphan baseline-branch
           fi
 
-          git rm -rf .
+          git rm -rf . --ignore-unmatch
           mkdir -p .github/visual-baselines/packs
           cp /tmp/visual-baseline-packs/* .github/visual-baselines/packs/
           git add .github/visual-baselines

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -75,10 +75,13 @@ on:
 env:
   # Visual Testing Configuration
   VISUAL_DIFF_THRESHOLD: ${{ github.event.inputs.diff_threshold || '2' }}
+  VISUAL_TILE_DIFF_THRESHOLD: '3'
   GITHUB_EVENT_INPUTS_TEST_SCOPE: ${{ github.event.inputs.test_scope || 'comprehensive' }}
   GITHUB_EVENT_INPUTS_TEST_RESOLUTION: ${{ github.event.inputs.test_resolution || 'standard' }}
-  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update || 'false' }}
-  BASELINE_BRANCH: 'main'
+  # The PR-head clause is a one-time bootstrap and is removed after the first
+  # reviewed baseline is published.
+  GITHUB_EVENT_INPUTS_BASELINE_UPDATE: ${{ github.event.inputs.baseline_update == 'true' || (github.event_name == 'pull_request' && github.head_ref == 'feat/visual-regression-baselines') }}
+  BASELINE_BRANCH: 'visual-baselines'
   SCREENSHOT_TIMEOUT: 30000
   PARALLEL_WORKERS: 4
   IMAGE_QUALITY: 90
@@ -130,6 +133,7 @@ jobs:
           import os
           import json
           import glob
+          import subprocess
           import yaml
           from pathlib import Path
           
@@ -400,7 +404,21 @@ jobs:
           test_matrix = generate_test_matrix(len(targets))
           
           # Check if baselines exist
-          baseline_exists = os.path.exists('.github/visual-baselines') or os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
+          baseline_branch = os.environ.get('BASELINE_BRANCH', 'visual-baselines')
+          remote_baseline_exists = subprocess.run(
+              [
+                  'git', 'ls-remote', '--exit-code', '--heads', 'origin',
+                  f'refs/heads/{baseline_branch}'
+              ],
+              stdout=subprocess.DEVNULL,
+              stderr=subprocess.DEVNULL,
+              check=False
+          ).returncode == 0
+          baseline_exists = (
+              os.path.exists('.github/visual-baselines')
+              or remote_baseline_exists
+              or os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
+          )
           
           # Generate summary
           summary = {
@@ -950,7 +968,7 @@ jobs:
   visual-comparison:
     name: 🔍 Visual Comparison
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [visual-discovery, visual-capture]
     if: always() && needs.visual-discovery.outputs.total_tests > 0
     
@@ -968,7 +986,6 @@ jobs:
 
       - name: 📥 Download Baseline Screenshots (if available)
         if: needs.visual-discovery.outputs.baseline_exists == 'true'
-        continue-on-error: true
         run: |
           echo "📥 Attempting to download baseline screenshots..."
           
@@ -978,20 +995,23 @@ jobs:
           if git show-ref --verify --quiet refs/heads/baseline-branch; then
             git checkout baseline-branch -- .github/visual-baselines/ || echo "No baselines found in baseline branch"
           fi
-          
-          # Also check for baselines in artifacts from previous runs
-          # This would require additional logic to download from previous successful runs
+
+          if compgen -G '.github/visual-baselines/packs/*.zip' > /dev/null; then
+            jq -r '.packs[] | "\(.sha256)  .github/visual-baselines/packs/\(.file)"' \
+              .github/visual-baselines/packs/manifest.json | sha256sum -c -
+            for pack in .github/visual-baselines/packs/*.zip; do
+              unzip -q -o "$pack" -d .github/visual-baselines/
+            done
+          fi
+
+          test -f .github/visual-baselines/packs/manifest.json
+          find .github/visual-baselines -type f \( -name '*.webp' -o -name '*.png' \) | grep -q .
 
       - name: 🛠️ Setup Image Comparison Tools
         run: |
           echo "🛠️ Setting up image comparison tools..."
-          
-          # Install ImageMagick for image comparison
-          sudo apt-get update
-          sudo apt-get install -y imagemagick
-          
-          # Install Python image processing libraries
-          pip install Pillow numpy opencv-python scikit-image
+
+          pip install Pillow numpy
           
           echo "✅ Image comparison tools ready"
 
@@ -1005,13 +1025,19 @@ jobs:
           import os
           import json
           import glob
+          from pathlib import Path
           from PIL import Image, ImageDraw, ImageFont
           import numpy as np
           from datetime import datetime
-          import subprocess
           import shutil
           
-          def compare_images(current_path, baseline_path, diff_path, threshold_percent=2):
+          def compare_images(
+              current_path,
+              baseline_path,
+              diff_path,
+              threshold_percent=2,
+              tile_threshold_percent=3
+          ):
               """Compare two images and generate diff"""
               
               try:
@@ -1032,10 +1058,21 @@ jobs:
                   # Calculate difference
                   diff_array = np.abs(current_array.astype(float) - baseline_array.astype(float))
                   
-                  # Calculate percentage difference
+                  # Mean absolute error is stable across compact WebP baselines.
+                  # A tiled maximum prevents local changes on long pages from
+                  # being diluted by the full-page average.
                   total_pixels = current_array.shape[0] * current_array.shape[1]
-                  changed_pixels = np.sum(np.any(diff_array > 10, axis=2))  # Threshold for "changed"
-                  diff_percentage = (changed_pixels / total_pixels) * 100
+                  diff_percentage = float(np.mean(diff_array) / 255 * 100)
+                  tile_height = 512
+                  tile_differences = [
+                      float(np.mean(diff_array[offset:offset + tile_height]) / 255 * 100)
+                      for offset in range(0, diff_array.shape[0], tile_height)
+                  ]
+                  max_tile_diff_percentage = max(tile_differences, default=0)
+                  threshold_exceeded = (
+                      diff_percentage > threshold_percent
+                      or max_tile_diff_percentage > tile_threshold_percent
+                  )
                   
                   # Create visual diff image
                   diff_image = Image.fromarray(diff_array.astype(np.uint8))
@@ -1061,16 +1098,21 @@ jobs:
                   
                   draw.text((10, 10), "BASELINE", fill='black', font=font)
                   draw.text((width + 10, 10), "CURRENT", fill='black', font=font)
-                  draw.text((width * 2 + 10, 10), f"DIFF ({diff_percentage:.2f}%)", fill='red' if diff_percentage > threshold_percent else 'green', font=font)
+                  draw.text(
+                      (width * 2 + 10, 10),
+                      f"DIFF ({diff_percentage:.2f}% / tile {max_tile_diff_percentage:.2f}%)",
+                      fill='red' if threshold_exceeded else 'green',
+                      font=font
+                  )
                   
                   # Save comparison
                   comparison.save(diff_path)
                   
                   return {
                       'diff_percentage': round(diff_percentage, 2),
-                      'changed_pixels': int(changed_pixels),
+                      'max_tile_diff_percentage': round(max_tile_diff_percentage, 2),
                       'total_pixels': int(total_pixels),
-                      'threshold_exceeded': diff_percentage > threshold_percent,
+                      'threshold_exceeded': threshold_exceeded,
                       'diff_image': diff_path
                   }
                   
@@ -1086,11 +1128,12 @@ jobs:
               """Find all screenshot files"""
               screenshot_files = {}
               
-              # Find all screenshot directories
-              screenshot_dirs = glob.glob('screenshots-*')
+              # download-artifact merges each shard into its browser/resolution
+              # directory (for example, chromium_desktop).
+              screenshot_dirs = glob.glob('chromium_*')
               
               for screenshot_dir in screenshot_dirs:
-                  browser_resolution = screenshot_dir.replace('screenshots-', '')
+                  browser_resolution = screenshot_dir
                   screenshot_files[browser_resolution] = glob.glob(f"{screenshot_dir}/*.png")
               
               return screenshot_files
@@ -1106,12 +1149,16 @@ jobs:
                   
                   for baseline_dir_path in baseline_dirs:
                       browser_resolution = os.path.basename(baseline_dir_path).replace('screenshots-', '')
-                      baseline_files[browser_resolution] = glob.glob(f"{baseline_dir_path}/*.png")
+                      baseline_files[browser_resolution] = (
+                          glob.glob(f"{baseline_dir_path}/*.webp")
+                          + glob.glob(f"{baseline_dir_path}/*.png")
+                      )
               
               return baseline_files
           
           # Main comparison process
           threshold_percent = float(os.environ.get('VISUAL_DIFF_THRESHOLD', '2'))
+          tile_threshold_percent = float(os.environ.get('VISUAL_TILE_DIFF_THRESHOLD', '3'))
           update_baseline = os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
           
           print(f"Visual comparison threshold: {threshold_percent}%")
@@ -1133,11 +1180,11 @@ jobs:
               print(f"\nProcessing {browser_resolution}...")
               
               baseline_files = baseline_screenshots.get(browser_resolution, [])
-              baseline_file_map = {os.path.basename(f): f for f in baseline_files}
+              baseline_file_map = {Path(f).stem: f for f in baseline_files}
               
               for current_file in current_files:
                   filename = os.path.basename(current_file)
-                  baseline_file = baseline_file_map.get(filename)
+                  baseline_file = baseline_file_map.get(Path(filename).stem)
                   
                   result = {
                       'browser_resolution': browser_resolution,
@@ -1153,7 +1200,13 @@ jobs:
                       diff_path = f"visual-comparison-results/{browser_resolution}_{filename.replace('.png', '_diff.png')}"
                       os.makedirs(os.path.dirname(diff_path), exist_ok=True)
                       
-                      comparison = compare_images(current_file, baseline_file, diff_path, threshold_percent)
+                      comparison = compare_images(
+                          current_file,
+                          baseline_file,
+                          diff_path,
+                          threshold_percent,
+                          tile_threshold_percent
+                      )
                       result.update(comparison)
                       
                       total_comparisons += 1
@@ -1188,6 +1241,12 @@ jobs:
           print(f"  Regressions found: {summary['regressions_found']}")
           print(f"  New screenshots: {summary['new_screenshots']}")
           print(f"  Regression rate: {summary['regression_rate']}%")
+
+          if summary['total_screenshots'] == 0:
+              raise SystemExit("No screenshots were discovered after artifact download")
+
+          if baseline_screenshots and total_comparisons == 0 and not update_baseline:
+              raise SystemExit("Baselines exist, but zero screenshots were compared")
           
           # Save detailed results
           with open('visual-comparison-results/comparison_results.json', 'w') as f:
@@ -1212,8 +1271,17 @@ jobs:
                   
                   for file_path in files:
                       filename = os.path.basename(file_path)
-                      target_path = f"{target_dir}/{filename}"
-                      shutil.copy2(file_path, target_path)
+                      target_path = f"{target_dir}/{Path(filename).stem}.webp"
+                      with Image.open(file_path).convert('RGB') as image:
+                          width, height = image.size
+                          baseline_width = 256
+                          scale = min(baseline_width / width, 16383 / height)
+                          baseline_width = max(1, round(width * scale))
+                          baseline_height = max(1, round(height * scale))
+                          image = image.resize(
+                              (baseline_width, baseline_height), Image.Resampling.LANCZOS
+                          )
+                          image.save(target_path, 'WEBP', quality=85, method=4)
                       print(f"    ✅ Updated baseline: {filename}")
               
               print("✅ Baseline update completed!")
@@ -1235,12 +1303,74 @@ jobs:
           retention-days: 30
 
       - name: 📤 Update Visual Baselines
-        if: github.event.inputs.baseline_update == 'true'
+        if: env.GITHUB_EVENT_INPUTS_BASELINE_UPDATE == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: visual-baselines-${{ github.run_number }}
           path: .github/visual-baselines/
           retention-days: 90
+
+  visual-baseline-publish:
+    name: 📌 Publish Reviewed Visual Baselines
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [visual-discovery, visual-capture, visual-comparison]
+    if: (github.event.inputs.baseline_update == 'true' || (github.event_name == 'pull_request' && github.head_ref == 'feat/visual-regression-baselines')) && needs.visual-capture.result == 'success' && needs.visual-comparison.result == 'success'
+    permissions:
+      contents: write
+
+    steps:
+      - name: 📥 Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 📥 Download Reviewed Screenshots
+        uses: actions/download-artifact@v8
+        with:
+          pattern: "screenshots-*-${{ github.run_number }}"
+          path: baseline-source-artifacts
+
+      - name: 📦 Build Compact Baseline Packs
+        env:
+          BASELINE_SOURCE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          pip install Pillow
+          python3 scripts/build-visual-baseline-packs.py \
+            baseline-source-artifacts \
+            /tmp/visual-baseline-packs \
+            --source-run "${{ github.run_id }}" \
+            --source-commit "$BASELINE_SOURCE_COMMIT"
+
+          jq -e '.total_screenshots > 0 and (.packs | length > 0)' \
+            /tmp/visual-baseline-packs/manifest.json > /dev/null
+          jq -r '.packs[] | "\(.sha256)  /tmp/visual-baseline-packs/\(.file)"' \
+            /tmp/visual-baseline-packs/manifest.json | sha256sum -c -
+          if find /tmp/visual-baseline-packs -name '*.zip' -size +99M -print -quit | grep -q .; then
+            echo 'A baseline pack exceeds GitHub size limits'
+            exit 1
+          fi
+
+      - name: 📌 Publish Baseline Branch
+        env:
+          BASELINE_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin "refs/heads/$BASELINE_BRANCH" > /dev/null 2>&1; then
+            git fetch origin "$BASELINE_BRANCH:baseline-branch"
+            git switch baseline-branch
+          else
+            git switch --orphan baseline-branch
+          fi
+
+          git rm -rf .
+          mkdir -p .github/visual-baselines/packs
+          cp /tmp/visual-baseline-packs/* .github/visual-baselines/packs/
+          git add .github/visual-baselines
+          git commit -m "test: publish reviewed visual baselines for $BASELINE_COMMIT"
+          git push origin "HEAD:$BASELINE_BRANCH"
 
   # Visual Regression Report
   visual-report:

--- a/.github/workflows/visual-regression-testing.yml
+++ b/.github/workflows/visual-regression-testing.yml
@@ -417,7 +417,6 @@ jobs:
           baseline_exists = (
               os.path.exists('.github/visual-baselines')
               or remote_baseline_exists
-              or os.environ.get('GITHUB_EVENT_INPUTS_BASELINE_UPDATE') == 'true'
           )
           
           # Generate summary

--- a/scripts/build-visual-baseline-packs.py
+++ b/scripts/build-visual-baseline-packs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Build compact, deterministic visual-regression baseline packs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from PIL import Image
+
+
+BASELINE_WIDTH = 256
+MAX_WEBP_DIMENSION = 16_383
+WEBP_QUALITY = 85
+WEBP_METHOD = 4
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def convert_image(source: Path, destination: Path) -> None:
+    with Image.open(source) as image:
+        image = image.convert("RGB")
+        width, height = image.size
+        scale = min(BASELINE_WIDTH / width, MAX_WEBP_DIMENSION / height)
+        baseline_width = max(1, round(width * scale))
+        baseline_height = max(1, round(height * scale))
+        image = image.resize(
+            (baseline_width, baseline_height), Image.Resampling.LANCZOS
+        )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        image.save(destination, "WEBP", quality=WEBP_QUALITY, method=WEBP_METHOD)
+
+
+def pack_name(source: Path) -> str:
+    name = source.stem if source.is_file() else source.name
+    name = re.sub(r"^screenshots-", "", name)
+    name = re.sub(r"-\d+$", "", name)
+    return f"{name}.zip"
+
+
+def write_deterministic_pack(source_dir: Path, pack_path: Path) -> None:
+    with zipfile.ZipFile(pack_path, "w", compression=zipfile.ZIP_STORED) as archive:
+        for baseline in sorted(source_dir.rglob("*.webp")):
+            relative_path = baseline.relative_to(source_dir).as_posix()
+            info = zipfile.ZipInfo(relative_path, date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, baseline.read_bytes())
+
+
+def build_pack(source: Path, output_dir: Path) -> dict[str, object]:
+    pack_path = output_dir / pack_name(source)
+    if pack_path.exists():
+        with zipfile.ZipFile(pack_path) as archive:
+            baselines = sorted(
+                path for path in archive.namelist() if path.endswith(".webp")
+            )
+        if not baselines:
+            raise ValueError(f"Existing pack has no WebP baselines: {pack_path}")
+        resolution_names = {Path(path).parent.name for path in baselines}
+        if len(resolution_names) != 1:
+            raise ValueError(f"Existing pack has mixed resolutions: {pack_path}")
+        return {
+            "file": pack_path.name,
+            "browser_resolution": resolution_names.pop().replace("screenshots-", ""),
+            "screenshots": len(baselines),
+            "bytes": pack_path.stat().st_size,
+            "sha256": sha256(pack_path),
+        }
+
+    with tempfile.TemporaryDirectory(prefix="visual-baseline-") as temp_dir:
+        extracted_dir = Path(temp_dir) / "extracted"
+        converted_dir = Path(temp_dir) / "converted"
+        if source.is_file():
+            with zipfile.ZipFile(source) as archive:
+                archive.extractall(extracted_dir)
+            source_dir = extracted_dir
+        else:
+            source_dir = source
+
+        sources = sorted(source_dir.rglob("*.png"))
+        if not sources:
+            raise ValueError(f"No PNG screenshots found in {source}")
+
+        resolution_names = {source.parent.name for source in sources}
+        if len(resolution_names) != 1:
+            raise ValueError(
+                f"Expected one browser/resolution directory in {source}; "
+                f"found {sorted(resolution_names)}"
+            )
+
+        resolution_name = resolution_names.pop()
+        baseline_dir = converted_dir / f"screenshots-{resolution_name}"
+        for source in sources:
+            convert_image(source, baseline_dir / f"{source.stem}.webp")
+
+        write_deterministic_pack(converted_dir, pack_path)
+
+    return {
+        "file": pack_path.name,
+        "browser_resolution": resolution_name,
+        "screenshots": len(sources),
+        "bytes": pack_path.stat().st_size,
+        "sha256": sha256(pack_path),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_dir", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--source-run", required=True, type=int)
+    parser.add_argument("--source-commit", required=True)
+    args = parser.parse_args()
+
+    sources = sorted(args.input_dir.glob("*.zip"))
+    if not sources:
+        sources = sorted(path for path in args.input_dir.iterdir() if path.is_dir())
+    if not sources:
+        raise SystemExit(f"No screenshot artifacts found in {args.input_dir}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    packs = [build_pack(source, args.output_dir) for source in sources]
+    manifest = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "source_workflow_run": args.source_run,
+        "source_commit": args.source_commit,
+        "format": "webp",
+        "width": BASELINE_WIDTH,
+        "maximum_dimension": MAX_WEBP_DIMENSION,
+        "quality": WEBP_QUALITY,
+        "method": WEBP_METHOD,
+        "total_screenshots": sum(int(pack["screenshots"]) for pack in packs),
+        "packs": packs,
+    }
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements the reviewed visual baselines captured by visual-regression run #352 and fixes the comparison path that previously allowed a zero-comparison run to report success.

Depends on #1078.

## Baseline design

- publishes baselines to a dedicated `visual-baselines` branch so routine repository checkouts do not inherit the binary payload
- stores deterministic, checksum-verified WebP packs derived from all 1,790 approved desktop/mobile captures
- keeps full-page layout coverage at a nominal 256-pixel width, proportionally scaling exceptionally tall pages within WebP limits
- records source run, source commit, encoding parameters, image counts, pack sizes, and SHA-256 digests in a manifest
- provides a reproducible pack builder at `scripts/build-visual-baseline-packs.py`

## Validation safeguards

- discovers the actual `chromium_desktop` and `chromium_mobile` artifact directories
- fails when no screenshots are found
- fails when baselines exist but zero comparisons execute
- verifies every baseline pack checksum before extraction
- uses global and tiled normalized image differences to tolerate encoding noise while detecting localized regressions
- refuses baseline packs at or above GitHub's per-file size limit
- publishes only after capture and comparison both succeed

## Bootstrap sequence

1. This draft PR performs the one-time approved baseline publication.
2. The temporary PR-head bootstrap clause is removed.
3. A second run must compare all 1,790 screenshots against the published baselines successfully before the PR is marked ready.

## Rollback

Revert this PR and delete the dedicated `visual-baselines` branch. No baseline binaries are added to `main` history.

## Governance references

- `docs/governance/task-closure-checklist.md`
- `docs/governance/rollback-plan-template.md`
- `docs/governance/security-compliance-checklist.md`
- `docs/governance/lessons-learned-template.md`

Related to #1057; does not close it.