### PR TITLE
Add dependency-aware migration wave tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,15 @@ jobs:
         run: ./scripts/measure_step.sh "npm install" -- bash -lc "if [ -f package-lock.json ]; then npm ci; else npm install; fi"
       - name: Test documentation scanner
         run: npm run test:doc-scan
+      - name: Test migration wave planner and validator
+        run: npm run test:migration-wave
+      - name: Validate recorded migration wave manifests
+        run: |
+          shopt -s nullglob
+          manifests=(meta/migration-waves/*.json)
+          for manifest in "${manifests[@]}"; do
+            node scripts/validate-migration-wave.mjs --manifest "$manifest"
+          done
       - name: Test (coverage, fail if below thresholds)
         run: ./scripts/measure_step.sh "unit tests (coverage)" -- npm run test:ci
       - uses: actions/upload-artifact@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
           date -u +"now_utc=%Y-%m-%dT%H:%M:%SZ"
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 1
+          # Manifest validation verifies that the rollback SHA exists and is an
+          # ancestor of the tested revision, which requires repository history.
+          fetch-depth: 0
       - name: Test sensitive-information scanner
         run: bash tests/detect-sensitive.test.sh
       - uses: actions/setup-node@v6

--- a/docs/vnext/sprint-12/migration-wave-operating-model.md
+++ b/docs/vnext/sprint-12/migration-wave-operating-model.md
@@ -1,0 +1,52 @@
+# Migration Wave Operating Model
+
+This operating model reduces the remaining domain migration from one-asset delivery batches to dependency-aware waves without weakening content integrity, compatibility, evidence, or rollback controls.
+
+## Guardrails
+
+- A wave contains 1–15 assets and normally targets one source batch and one primary domain.
+- The planner records every source, destination, pre-move SHA-256 hash, dependency disposition, and rollback owner before execution.
+- A missing dependency blocks the wave. Dependencies already migrated, included in the same wave, or intentionally deferred at a usable existing path are recorded explicitly.
+- The wave is the production rollback boundary. Each asset retains an individual hash and move record for diagnosis.
+- Maintained catalogs, mappings, references, legacy pointers, and the version-controlled evidence record change in the same delivery PR.
+- Evidence text must be final before reviewed visual baselines are approved.
+- The generated manifest starts with `phase: entry`. The migration PR changes it to `phase: executed`; CI then verifies destination hashes, execution batch IDs, and legacy-pointer resolution.
+
+## Validation tiers
+
+1. **Entry:** validate the generated manifest and baseline repository state.
+2. **PR affected scope:** run migration validators, curated/canonical path checks, filtered links, focused tests, and affected-file visual regression.
+3. **Wave exit:** require all PR checks and reviewed changed-image baselines.
+4. **Post-merge:** verify canonical and legacy `/blob/main/...` paths, hashes, CI, and one comprehensive visual run.
+
+The comprehensive visual suite remains mandatory once per merged wave. Evidence-only changes are completed before baseline approval so they do not create a second post-merge baseline cycle.
+
+## Commands
+
+Generate a wave definition:
+
+```bash
+node scripts/plan-migration-wave.mjs \
+  --wave-id B1F \
+  --batch 1 \
+  --domain Stakeholder \
+  --max-assets 12 \
+  --rollback-owner mirichard \
+  --output meta/migration-waves/b1f.json
+```
+
+Validate it before any move:
+
+```bash
+node scripts/validate-migration-wave.mjs --manifest meta/migration-waves/b1f.json
+```
+
+During execution, retain the recorded pre-move hashes and change the manifest phase to `executed`. The same validator then checks the post-move state.
+
+Rollback after integration:
+
+```bash
+git revert <wave-merge-sha>
+```
+
+After rollback, regenerate migration metadata and the template index, rerun the complete validation suite, and record the revert SHA in #1057 and #711.

--- a/meta/migration-waves/b1f.json
+++ b/meta/migration-waves/b1f.json
@@ -1,0 +1,255 @@
+{
+  "schema_version": 1,
+  "wave_id": "B1F",
+  "phase": "entry",
+  "source_batch": 1,
+  "primary_domain": "Stakeholder",
+  "generated_from": "meta/migration-inventory.json",
+  "inventory_generated": "2026-09-02",
+  "pre_batch_sha": "2142d620faa6adb5c4ba0437265730cde1f41203",
+  "rollback_owner": "mirichard",
+  "max_assets": 12,
+  "asset_count": 8,
+  "assets": [
+    {
+      "order": 1,
+      "source": "business-stakeholder-suite/executive-dashboards/Word/Executive-Report-Templates.md",
+      "destination": "domains/stakeholder/business-stakeholder-suite/executive-dashboards/Word/Executive-Report-Templates.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [],
+      "pre_move_sha256": "1338a81251bc9956211cbdf2a8473105aca45b45ee8607fbdac59a0524119381",
+      "dependencies": [
+        {
+          "path": "industry-specializations/information-technology/security/cybersecurity_assessment_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/security/cybersecurity_assessment_template.md"
+        },
+        {
+          "path": "domains/planning/role-based-toolkits/project-manager/essential-templates/budget-template.md",
+          "status": "satisfied-executed",
+          "resolved_path": "domains/planning/role-based-toolkits/project-manager/essential-templates/budget-template.md"
+        },
+        {
+          "path": "project-lifecycle/02-planning/business-requirements/business_requirements_document_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "project-lifecycle/02-planning/business-requirements/business_requirements_document_template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 2,
+      "source": "business-stakeholder-suite/executive-dashboards/powerbi-integration/executive-dashboard-template.md",
+      "destination": "domains/stakeholder/business-stakeholder-suite/executive-dashboards/powerbi-integration/executive-dashboard-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [],
+      "pre_move_sha256": "2f7f07ed73be740db85f2e104d859701da83cf205f731b8a465a0e80e445872b",
+      "dependencies": [
+        {
+          "path": "industry-specializations/information-technology/security/cybersecurity_assessment_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/security/cybersecurity_assessment_template.md"
+        },
+        {
+          "path": "business-stakeholder-suite/executive-dashboards/Word/Executive-Report-Templates.md",
+          "status": "same-wave",
+          "resolved_path": "domains/stakeholder/business-stakeholder-suite/executive-dashboards/Word/Executive-Report-Templates.md"
+        },
+        {
+          "path": "industry-specializations/information-technology/cybersecurity/risk_assessment_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/cybersecurity/risk_assessment_template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 3,
+      "source": "business-stakeholder-suite/financial-governance/budget-dashboard-template.md",
+      "destination": "domains/stakeholder/business-stakeholder-suite/financial-governance/budget-dashboard-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [],
+      "pre_move_sha256": "167f338626bb4c864e00458699a36be5687b998c92d37103e1a286de53bd88ee",
+      "dependencies": [
+        {
+          "path": "domains/stakeholder/business-stakeholder-suite/financial-governance/enhanced-business-cases/evm-dashboard-template.md",
+          "status": "satisfied-executed",
+          "resolved_path": "domains/stakeholder/business-stakeholder-suite/financial-governance/enhanced-business-cases/evm-dashboard-template.md"
+        },
+        {
+          "path": "industry-specializations/information-technology/software-development/test_plan_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/software-development/test_plan_template.md"
+        },
+        {
+          "path": "business-stakeholder-suite/executive-dashboards/powerbi-integration/executive-dashboard-template.md",
+          "status": "same-wave",
+          "resolved_path": "domains/stakeholder/business-stakeholder-suite/executive-dashboards/powerbi-integration/executive-dashboard-template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 4,
+      "source": "business-stakeholder-suite/financial-governance/enhanced-business-cases/advanced-business-case-template.md",
+      "destination": "domains/stakeholder/business-stakeholder-suite/financial-governance/enhanced-business-cases/advanced-business-case-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [
+        "Planning"
+      ],
+      "pre_move_sha256": "b9fca0975cc801353e0ff7ddac459ea8631fdd7fc9498bf55c07d769b8ea04df",
+      "dependencies": [
+        {
+          "path": "industry-specializations/information-technology/cybersecurity/risk_assessment_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/cybersecurity/risk_assessment_template.md"
+        },
+        {
+          "path": "domains/stakeholder/business-stakeholder-suite/financial-governance/enhanced-business-cases/evm-dashboard-template.md",
+          "status": "satisfied-executed",
+          "resolved_path": "domains/stakeholder/business-stakeholder-suite/financial-governance/enhanced-business-cases/evm-dashboard-template.md"
+        },
+        {
+          "path": "industry-specializations/information-technology/software-development/user_story_mapping_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "industry-specializations/information-technology/software-development/user_story_mapping_template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 5,
+      "source": "project-assessment-suite/waterfall-project-assessment-template.md",
+      "destination": "domains/stakeholder/project-assessment-suite/waterfall-project-assessment-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [],
+      "pre_move_sha256": "95165f9cbf36fa6dc2e812e45a845342b045c6fa072f3126994feab5a7128404",
+      "dependencies": [
+        {
+          "path": "templates/traditional/Traditional/Templates/change_request_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "templates/traditional/Traditional/Templates/change_request_template.md"
+        },
+        {
+          "path": "templates/traditional/Traditional/Templates/communication_plan_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "templates/traditional/Traditional/Templates/communication_plan_template.md"
+        },
+        {
+          "path": "templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "templates/traditional/Traditional/Process_Groups/Initiating/project_charter_template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 6,
+      "source": "project-lifecycle/01-initiation/stakeholder-analysis/agile-stakeholder-map-template.md",
+      "destination": "domains/stakeholder/project-lifecycle/01-initiation/stakeholder-analysis/agile-stakeholder-map-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [
+        "Planning"
+      ],
+      "pre_move_sha256": "a9312efad04f7976d8e03c39f0ac59658001629c1c0d57150db91c44ccea9f17",
+      "dependencies": [
+        {
+          "path": "project-lifecycle/02-planning/project-management-plan/traditional-project-management-plan-template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "project-lifecycle/02-planning/project-management-plan/traditional-project-management-plan-template.md"
+        },
+        {
+          "path": "project-assessment-suite/agile-project-assessment-template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "project-assessment-suite/agile-project-assessment-template.md"
+        },
+        {
+          "path": "methodology-frameworks/emerging-methods/devops/monitoring_alerting_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "methodology-frameworks/emerging-methods/devops/monitoring_alerting_template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 7,
+      "source": "project-assessment-suite/stakeholder-engagement-assessment-template.md",
+      "destination": "domains/stakeholder/project-assessment-suite/stakeholder-engagement-assessment-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [
+        "Planning"
+      ],
+      "pre_move_sha256": "f75d1438fe08ec594fda5f649f2fdb9c014677fcd2b8e46fc5eb04db35f19e2c",
+      "dependencies": [
+        {
+          "path": "project-assessment-suite/agile-project-assessment-template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "project-assessment-suite/agile-project-assessment-template.md"
+        },
+        {
+          "path": "role-based-toolkits/product-owner/okr-template.md",
+          "status": "same-wave",
+          "resolved_path": "domains/stakeholder/role-based-toolkits/product-owner/okr-template.md"
+        },
+        {
+          "path": "project-assessment-suite/process-maturity-assessment-template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "project-assessment-suite/process-maturity-assessment-template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    },
+    {
+      "order": 8,
+      "source": "role-based-toolkits/product-owner/okr-template.md",
+      "destination": "domains/stakeholder/role-based-toolkits/product-owner/okr-template.md",
+      "primary_domain": "Stakeholder",
+      "secondary_domains": [
+        "Planning"
+      ],
+      "pre_move_sha256": "8275b3a215747acf56a7a6324a5994ce78a312548bcfba25fda8b712a172e841",
+      "dependencies": [
+        {
+          "path": "role-based-toolkits/project-manager/essential-templates/meeting-templates.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "role-based-toolkits/project-manager/essential-templates/meeting-templates.md"
+        },
+        {
+          "path": "methodology-frameworks/emerging-methods/devops/monitoring_alerting_template.md",
+          "status": "satisfied-existing-deferred",
+          "resolved_path": "methodology-frameworks/emerging-methods/devops/monitoring_alerting_template.md"
+        },
+        {
+          "path": "project-assessment-suite/stakeholder-engagement-assessment-template.md",
+          "status": "same-wave",
+          "resolved_path": "domains/stakeholder/project-assessment-suite/stakeholder-engagement-assessment-template.md"
+        }
+      ],
+      "legacy_strategy": "replace-source-with-relative-pointer-after-approved-move"
+    }
+  ],
+  "checkpoints": [
+    "baseline-and-hashes",
+    "canonical-moves",
+    "legacy-pointers",
+    "canonical-references",
+    "affected-scope-validation",
+    "reviewed-visual-regression",
+    "post-merge-verification"
+  ],
+  "validation_commands": [
+    "node scripts/validate-migration-wave.mjs --manifest <manifest>",
+    "node scripts/generate-sprint-10-metadata.mjs",
+    "node scripts/validate-sprint-10.mjs --require-annotations",
+    "node scripts/validate-curated-templates.js",
+    "node scripts/validate-canonical-paths.js --strict",
+    "python3 scripts/check_anchor_links_filtered.py",
+    "npm run test:ci"
+  ],
+  "rollback": {
+    "strategy": "revert-wave-merge-commit",
+    "command": "git revert <wave-merge-sha>",
+    "granularity": "wave",
+    "asset_hashes_preserved": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "doc-scan": "node scripts/doc-scan.js",
     "test:doc-scan": "node --test tests/doc-scan.test.js",
     "template-selector": "node scripts/template-selector.mjs",
-    "test:webhook": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config integrations/webhook-framework/jest.config.webhook.js --runInBand --testMatch \"**/integrations/webhook-framework/tests/**/*.test.js\""
+    "test:webhook": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --config integrations/webhook-framework/jest.config.webhook.js --runInBand --testMatch \"**/integrations/webhook-framework/tests/**/*.test.js\"",
+    "test:migration-wave": "node --test tests/migration-wave.test.mjs",
+    "plan:migration-wave": "node scripts/plan-migration-wave.mjs",
+    "validate:migration-wave": "node scripts/validate-migration-wave.mjs"
   },
   "keywords": [
     "project-management",

--- a/scripts/generate-sprint-10-metadata.mjs
+++ b/scripts/generate-sprint-10-metadata.mjs
@@ -24,7 +24,9 @@ const mappings = domainMap.mappings.filter(item => fs.existsSync(path.join(root,
 const byPath = new Map(templateDb.templates.map(item => [normalize(item.canonical_path || item.path), item]));
 
 const textFiles = [];
-const ignored = new Set(['.git', 'node_modules', 'coverage', 'dist', 'build']);
+// Wave manifests are planning metadata. Counting their self-references as inbound
+// links would make generation drift as soon as a proposed wave is recorded.
+const ignored = new Set(['.git', 'node_modules', 'coverage', 'dist', 'build', 'migration-waves']);
 function walk(directory) {
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     if (ignored.has(entry.name)) continue;

--- a/scripts/lib/migration-wave.mjs
+++ b/scripts/lib/migration-wave.mjs
@@ -180,10 +180,12 @@ export function validateWavePlan({ root, inventory, plan }) {
       else if (sha256File(destinationPath) !== asset.pre_move_sha256) fail(`destination hash mismatch: ${asset.destination}`);
       if (move.execution?.batch_id !== plan.wave_id) fail(`execution batch_id mismatch: ${asset.source}`);
       if (fs.existsSync(sourcePath)) {
-        const pointer = fs.readFileSync(sourcePath, 'utf8').match(/\[[^\]]+\]\(([^)]+)\)/);
-        if (!pointer) fail(`legacy pointer is missing: ${asset.source}`);
+        const pointer = fs.readFileSync(sourcePath, 'utf8')
+          .match(/^\s*\*{0,2}Canonical location:?\*{0,2}\s*\[[^\]]+\]\(([^)]+)\)/im);
+        if (!pointer?.[1]) fail(`legacy pointer is missing: ${asset.source}`);
         else {
-          const resolved = path.resolve(path.dirname(sourcePath), pointer[1].split('#')[0]);
+          const target = pointer[1].split('#')[0].trim().replace(/^<|>$/g, '');
+          const resolved = path.resolve(path.dirname(sourcePath), target);
           if (resolved !== destinationPath) fail(`legacy pointer does not resolve to destination: ${asset.source}`);
         }
       }

--- a/scripts/lib/migration-wave.mjs
+++ b/scripts/lib/migration-wave.mjs
@@ -1,9 +1,19 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 export const MAX_WAVE_ASSETS = 15;
 export const DEFAULT_WAVE_ASSETS = 12;
+export const REQUIRED_CHECKPOINTS = [
+  'baseline-and-hashes',
+  'canonical-moves',
+  'legacy-pointers',
+  'canonical-references',
+  'affected-scope-validation',
+  'reviewed-visual-regression',
+  'post-merge-verification'
+];
 
 export function sha256File(file) {
   return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
@@ -11,11 +21,11 @@ export function sha256File(file) {
 
 export function classifyDependency(root, dependency, inventoryByPath, selectedPaths) {
   const linked = inventoryByPath.get(dependency);
-  if (linked?.action === 'executed-move-with-legacy-pointer') {
-    return { path: dependency, status: 'satisfied-executed', resolved_path: linked.destination };
-  }
   if (linked && (selectedPaths.has(linked.source) || selectedPaths.has(linked.destination))) {
     return { path: dependency, status: 'same-wave', resolved_path: linked.destination };
+  }
+  if (linked?.action === 'executed-move-with-legacy-pointer') {
+    return { path: dependency, status: 'satisfied-executed', resolved_path: linked.destination };
   }
   if (fs.existsSync(path.join(root, dependency))) {
     return { path: dependency, status: 'satisfied-existing-deferred', resolved_path: dependency };
@@ -99,15 +109,7 @@ export function buildWavePlan({
     max_assets: maxAssets,
     asset_count: assets.length,
     assets,
-    checkpoints: [
-      'baseline-and-hashes',
-      'canonical-moves',
-      'legacy-pointers',
-      'canonical-references',
-      'affected-scope-validation',
-      'reviewed-visual-regression',
-      'post-merge-verification'
-    ],
+    checkpoints: [...REQUIRED_CHECKPOINTS],
     validation_commands: [
       'node scripts/validate-migration-wave.mjs --manifest <manifest>',
       'node scripts/generate-sprint-10-metadata.mjs',
@@ -143,11 +145,36 @@ export function validateWavePlan({ root, inventory, plan }) {
   }
   if (!plan.inventory_generated) fail('inventory_generated is required');
   else if (plan.inventory_generated !== inventory.generated) fail('inventory_generated does not match migration inventory snapshot');
-  if (!/^[0-9a-f]{40}$/.test(plan.pre_batch_sha || '')) fail('pre_batch_sha must be a 40-character Git SHA');
+  if (!/^[0-9a-f]{40}$/.test(plan.pre_batch_sha || '')) {
+    fail('pre_batch_sha must be a 40-character Git SHA');
+  } else {
+    let checkpointExists = true;
+    try {
+      execFileSync('git', ['cat-file', '-e', `${plan.pre_batch_sha}^{commit}`], { cwd: root, stdio: 'ignore' });
+    } catch {
+      checkpointExists = false;
+      fail('pre_batch_sha does not resolve to a commit');
+    }
+    if (checkpointExists) {
+      try {
+        execFileSync('git', ['merge-base', '--is-ancestor', plan.pre_batch_sha, 'HEAD'], { cwd: root, stdio: 'ignore' });
+      } catch {
+        fail('pre_batch_sha is not an ancestor of HEAD');
+      }
+    }
+  }
   if (!plan.rollback_owner) fail('rollback_owner is required');
+  if (JSON.stringify(plan.checkpoints) !== JSON.stringify(REQUIRED_CHECKPOINTS)) {
+    fail('checkpoints must contain the complete ordered checkpoint set');
+  }
+  if (plan.rollback?.strategy !== 'revert-wave-merge-commit') fail('rollback strategy is missing or unsupported');
   if (plan.rollback?.command !== 'git revert <wave-merge-sha>') fail('rollback command is missing or unsupported');
+  if (plan.rollback?.granularity !== 'wave') fail('rollback granularity must be wave');
+  if (plan.rollback?.asset_hashes_preserved !== true) fail('rollback must preserve asset hashes');
 
   const bySource = new Map(inventory.moves.map(move => [move.source, move]));
+  const inventoryByPath = new Map(inventory.moves.flatMap(move => [[move.source, move], [move.destination, move]]));
+  const selectedPaths = new Set((plan.assets || []).flatMap(asset => [asset.source, asset.destination]));
   const sources = new Set();
   const destinations = new Set();
   for (const asset of plan.assets || []) {
@@ -190,8 +217,21 @@ export function validateWavePlan({ root, inventory, plan }) {
         }
       }
     }
-    for (const dependency of asset.dependencies || []) {
-      if (dependency.status === 'blocked-missing') fail(`missing dependency: ${dependency.path}`);
+    const recordedDependencies = Array.isArray(asset.dependencies) ? asset.dependencies : [];
+    const expectedDependencyPaths = move.dependencies || [];
+    if (recordedDependencies.length !== expectedDependencyPaths.length) {
+      fail(`dependency count mismatch: ${asset.source}`);
+    }
+    for (let index = 0; index < expectedDependencyPaths.length; index += 1) {
+      const dependencyPath = expectedDependencyPaths[index];
+      const recorded = recordedDependencies[index];
+      const expected = classifyDependency(root, dependencyPath, inventoryByPath, selectedPaths);
+      if (!recorded || recorded.path !== expected.path) fail(`dependency path mismatch: ${asset.source}`);
+      if (!recorded || recorded.status !== expected.status) fail(`dependency status mismatch: ${asset.source} -> ${dependencyPath}`);
+      if (!recorded || recorded.resolved_path !== expected.resolved_path) {
+        fail(`dependency resolved path mismatch: ${asset.source} -> ${dependencyPath}`);
+      }
+      if (expected.status === 'blocked-missing') fail(`missing dependency: ${dependencyPath}`);
     }
   }
   return errors;

--- a/scripts/lib/migration-wave.mjs
+++ b/scripts/lib/migration-wave.mjs
@@ -138,6 +138,11 @@ export function validateWavePlan({ root, inventory, plan }) {
   if (!Array.isArray(plan.assets) || plan.assets.length === 0) fail('assets must be a non-empty array');
   if (plan.assets?.length > plan.max_assets) fail('asset count exceeds max_assets');
   if (plan.asset_count !== plan.assets?.length) fail('asset_count does not match assets length');
+  if (plan.generated_from !== 'meta/migration-inventory.json') {
+    fail('generated_from must be meta/migration-inventory.json');
+  }
+  if (!plan.inventory_generated) fail('inventory_generated is required');
+  else if (plan.inventory_generated !== inventory.generated) fail('inventory_generated does not match migration inventory snapshot');
   if (!/^[0-9a-f]{40}$/.test(plan.pre_batch_sha || '')) fail('pre_batch_sha must be a 40-character Git SHA');
   if (!plan.rollback_owner) fail('rollback_owner is required');
   if (plan.rollback?.command !== 'git revert <wave-merge-sha>') fail('rollback command is missing or unsupported');

--- a/scripts/lib/migration-wave.mjs
+++ b/scripts/lib/migration-wave.mjs
@@ -1,0 +1,191 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const MAX_WAVE_ASSETS = 15;
+export const DEFAULT_WAVE_ASSETS = 12;
+
+export function sha256File(file) {
+  return crypto.createHash('sha256').update(fs.readFileSync(file)).digest('hex');
+}
+
+export function classifyDependency(root, dependency, inventoryByPath, selectedPaths) {
+  const linked = inventoryByPath.get(dependency);
+  if (linked?.action === 'executed-move-with-legacy-pointer') {
+    return { path: dependency, status: 'satisfied-executed', resolved_path: linked.destination };
+  }
+  if (linked && (selectedPaths.has(linked.source) || selectedPaths.has(linked.destination))) {
+    return { path: dependency, status: 'same-wave', resolved_path: linked.destination };
+  }
+  if (fs.existsSync(path.join(root, dependency))) {
+    return { path: dependency, status: 'satisfied-existing-deferred', resolved_path: dependency };
+  }
+  return { path: dependency, status: 'blocked-missing', resolved_path: dependency };
+}
+
+function dependencyOrder(moves) {
+  const selectedByPath = new Map(moves.flatMap(move => [[move.source, move], [move.destination, move]]));
+  const remaining = new Set(moves);
+  const ordered = [];
+  while (remaining.size > 0) {
+    const ready = [...remaining]
+      .filter(move => (move.dependencies || []).every(dependency => {
+        const prerequisite = selectedByPath.get(dependency);
+        return !prerequisite || !remaining.has(prerequisite);
+      }))
+      .sort((a, b) => a.source.localeCompare(b.source));
+    // A cycle can be migrated atomically in one wave. Break it deterministically
+    // while retaining explicit same-wave dependency classifications.
+    const next = ready[0] || [...remaining].sort((a, b) => a.source.localeCompare(b.source))[0];
+    ordered.push(next);
+    remaining.delete(next);
+  }
+  return ordered;
+}
+
+export function buildWavePlan({
+  root,
+  inventory,
+  waveId,
+  sourceBatch,
+  primaryDomain,
+  maxAssets = DEFAULT_WAVE_ASSETS,
+  preBatchSha,
+  rollbackOwner
+}) {
+  if (!Number.isInteger(maxAssets) || maxAssets < 1 || maxAssets > MAX_WAVE_ASSETS) {
+    throw new Error(`max-assets must be between 1 and ${MAX_WAVE_ASSETS}`);
+  }
+
+  const candidates = inventory.moves
+    .filter(move => move.action === 'planned-move-not-executed')
+    .filter(move => move.batch === sourceBatch)
+    .filter(move => !primaryDomain || move.primary_domain === primaryDomain)
+    .sort((a, b) => a.source.localeCompare(b.source));
+
+  if (candidates.length === 0) throw new Error('No planned moves match the requested batch/domain');
+  const selected = dependencyOrder(candidates.slice(0, maxAssets));
+  const selectedPaths = new Set(selected.flatMap(move => [move.source, move.destination]));
+  const inventoryByPath = new Map(inventory.moves.flatMap(move => [[move.source, move], [move.destination, move]]));
+
+  const assets = selected.map((move, index) => ({
+    order: index + 1,
+    source: move.source,
+    destination: move.destination,
+    primary_domain: move.primary_domain,
+    secondary_domains: move.secondary_domains || [],
+    pre_move_sha256: sha256File(path.join(root, move.source)),
+    dependencies: (move.dependencies || []).map(dependency =>
+      classifyDependency(root, dependency, inventoryByPath, selectedPaths)
+    ),
+    legacy_strategy: move.legacy_strategy
+  }));
+
+  const blocked = assets.flatMap(asset => asset.dependencies.filter(item => item.status === 'blocked-missing'));
+  if (blocked.length > 0) {
+    throw new Error(`Wave contains missing dependencies: ${blocked.map(item => item.path).join(', ')}`);
+  }
+
+  return {
+    schema_version: 1,
+    wave_id: waveId,
+    phase: 'entry',
+    source_batch: sourceBatch,
+    primary_domain: primaryDomain || 'mixed',
+    generated_from: 'meta/migration-inventory.json',
+    inventory_generated: inventory.generated,
+    pre_batch_sha: preBatchSha,
+    rollback_owner: rollbackOwner,
+    max_assets: maxAssets,
+    asset_count: assets.length,
+    assets,
+    checkpoints: [
+      'baseline-and-hashes',
+      'canonical-moves',
+      'legacy-pointers',
+      'canonical-references',
+      'affected-scope-validation',
+      'reviewed-visual-regression',
+      'post-merge-verification'
+    ],
+    validation_commands: [
+      'node scripts/validate-migration-wave.mjs --manifest <manifest>',
+      'node scripts/generate-sprint-10-metadata.mjs',
+      'node scripts/validate-sprint-10.mjs --require-annotations',
+      'node scripts/validate-curated-templates.js',
+      'node scripts/validate-canonical-paths.js --strict',
+      'python3 scripts/check_anchor_links_filtered.py',
+      'npm run test:ci'
+    ],
+    rollback: {
+      strategy: 'revert-wave-merge-commit',
+      command: 'git revert <wave-merge-sha>',
+      granularity: 'wave',
+      asset_hashes_preserved: true
+    }
+  };
+}
+
+export function validateWavePlan({ root, inventory, plan }) {
+  const errors = [];
+  const fail = message => errors.push(message);
+  if (plan.schema_version !== 1) fail('schema_version must be 1');
+  if (!['entry', 'executed'].includes(plan.phase)) fail('phase must be entry or executed');
+  if (!/^B\d+[A-Z]+$/.test(plan.wave_id || '')) fail('wave_id must look like B1F');
+  if (!Number.isInteger(plan.max_assets) || plan.max_assets < 1 || plan.max_assets > MAX_WAVE_ASSETS) {
+    fail(`max_assets must be between 1 and ${MAX_WAVE_ASSETS}`);
+  }
+  if (!Array.isArray(plan.assets) || plan.assets.length === 0) fail('assets must be a non-empty array');
+  if (plan.assets?.length > plan.max_assets) fail('asset count exceeds max_assets');
+  if (plan.asset_count !== plan.assets?.length) fail('asset_count does not match assets length');
+  if (!/^[0-9a-f]{40}$/.test(plan.pre_batch_sha || '')) fail('pre_batch_sha must be a 40-character Git SHA');
+  if (!plan.rollback_owner) fail('rollback_owner is required');
+  if (plan.rollback?.command !== 'git revert <wave-merge-sha>') fail('rollback command is missing or unsupported');
+
+  const bySource = new Map(inventory.moves.map(move => [move.source, move]));
+  const sources = new Set();
+  const destinations = new Set();
+  for (const asset of plan.assets || []) {
+    if (sources.has(asset.source)) fail(`duplicate source: ${asset.source}`);
+    if (destinations.has(asset.destination)) fail(`duplicate destination: ${asset.destination}`);
+    sources.add(asset.source);
+    destinations.add(asset.destination);
+    const move = bySource.get(asset.source);
+    if (!move) {
+      fail(`source is absent from migration inventory: ${asset.source}`);
+      continue;
+    }
+    const expectedAction = plan.phase === 'executed'
+      ? 'executed-move-with-legacy-pointer'
+      : 'planned-move-not-executed';
+    if (move.action !== expectedAction) fail(`source action does not match ${plan.phase} phase: ${asset.source}`);
+    if (move.destination !== asset.destination) fail(`destination mismatch: ${asset.source}`);
+    if (move.batch !== plan.source_batch) fail(`source batch mismatch: ${asset.source}`);
+    if (plan.primary_domain !== 'mixed' && move.primary_domain !== plan.primary_domain) {
+      fail(`primary domain mismatch: ${asset.source}`);
+    }
+    const sourcePath = path.join(root, asset.source);
+    const destinationPath = path.join(root, asset.destination);
+    if (!fs.existsSync(sourcePath)) fail(`source does not exist: ${asset.source}`);
+    if (plan.phase === 'entry') {
+      if (fs.existsSync(sourcePath) && sha256File(sourcePath) !== asset.pre_move_sha256) fail(`source hash mismatch: ${asset.source}`);
+      if (fs.existsSync(destinationPath)) fail(`destination already exists: ${asset.destination}`);
+    } else {
+      if (!fs.existsSync(destinationPath)) fail(`executed destination does not exist: ${asset.destination}`);
+      else if (sha256File(destinationPath) !== asset.pre_move_sha256) fail(`destination hash mismatch: ${asset.destination}`);
+      if (move.execution?.batch_id !== plan.wave_id) fail(`execution batch_id mismatch: ${asset.source}`);
+      if (fs.existsSync(sourcePath)) {
+        const pointer = fs.readFileSync(sourcePath, 'utf8').match(/\[[^\]]+\]\(([^)]+)\)/);
+        if (!pointer) fail(`legacy pointer is missing: ${asset.source}`);
+        else {
+          const resolved = path.resolve(path.dirname(sourcePath), pointer[1].split('#')[0]);
+          if (resolved !== destinationPath) fail(`legacy pointer does not resolve to destination: ${asset.source}`);
+        }
+      }
+    }
+    for (const dependency of asset.dependencies || []) {
+      if (dependency.status === 'blocked-missing') fail(`missing dependency: ${dependency.path}`);
+    }
+  }
+  return errors;
+}

--- a/scripts/plan-migration-wave.mjs
+++ b/scripts/plan-migration-wave.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { buildWavePlan, DEFAULT_WAVE_ASSETS } from './lib/migration-wave.mjs';
+
+function argumentsFrom(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith('--') || value === undefined) throw new Error(`Invalid argument near ${name || '<end>'}`);
+    options[name.slice(2)] = value;
+  }
+  return options;
+}
+
+const root = process.cwd();
+const args = argumentsFrom(process.argv.slice(2));
+for (const required of ['wave-id', 'batch', 'domain', 'rollback-owner']) {
+  if (!args[required]) throw new Error(`--${required} is required`);
+}
+const inventory = JSON.parse(fs.readFileSync(path.join(root, args.inventory || 'meta/migration-inventory.json'), 'utf8'));
+const preBatchSha = args['pre-batch-sha'] || execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+const plan = buildWavePlan({
+  root,
+  inventory,
+  waveId: args['wave-id'],
+  sourceBatch: Number(args.batch),
+  primaryDomain: args.domain,
+  maxAssets: Number(args['max-assets'] || DEFAULT_WAVE_ASSETS),
+  preBatchSha,
+  rollbackOwner: args['rollback-owner']
+});
+const output = `${JSON.stringify(plan, null, 2)}\n`;
+if (args.output) {
+  fs.mkdirSync(path.dirname(path.join(root, args.output)), { recursive: true });
+  fs.writeFileSync(path.join(root, args.output), output);
+  console.log(`Wrote ${plan.wave_id}: ${plan.asset_count} assets to ${args.output}`);
+} else {
+  process.stdout.write(output);
+}

--- a/scripts/plan-migration-wave.mjs
+++ b/scripts/plan-migration-wave.mjs
@@ -20,7 +20,7 @@ const args = argumentsFrom(process.argv.slice(2));
 for (const required of ['wave-id', 'batch', 'domain', 'rollback-owner']) {
   if (!args[required]) throw new Error(`--${required} is required`);
 }
-if (args.inventory && path.resolve(root, args.inventory) !== path.resolve(root, 'meta/migration-inventory.json')) {
+if (args.inventory && args.inventory !== 'meta/migration-inventory.json') {
   throw new Error('--inventory currently supports only meta/migration-inventory.json');
 }
 const inventory = JSON.parse(fs.readFileSync(path.join(root, args.inventory || 'meta/migration-inventory.json'), 'utf8'));

--- a/scripts/plan-migration-wave.mjs
+++ b/scripts/plan-migration-wave.mjs
@@ -20,6 +20,9 @@ const args = argumentsFrom(process.argv.slice(2));
 for (const required of ['wave-id', 'batch', 'domain', 'rollback-owner']) {
   if (!args[required]) throw new Error(`--${required} is required`);
 }
+if (args.inventory && path.resolve(root, args.inventory) !== path.resolve(root, 'meta/migration-inventory.json')) {
+  throw new Error('--inventory currently supports only meta/migration-inventory.json');
+}
 const inventory = JSON.parse(fs.readFileSync(path.join(root, args.inventory || 'meta/migration-inventory.json'), 'utf8'));
 const preBatchSha = args['pre-batch-sha'] || execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
 const plan = buildWavePlan({

--- a/scripts/validate-migration-wave.mjs
+++ b/scripts/validate-migration-wave.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { validateWavePlan } from './lib/migration-wave.mjs';
+
+const index = process.argv.indexOf('--manifest');
+if (index < 0 || !process.argv[index + 1]) throw new Error('--manifest <path> is required');
+const root = process.cwd();
+const manifestPath = process.argv[index + 1];
+const inventory = JSON.parse(fs.readFileSync(path.join(root, 'meta/migration-inventory.json'), 'utf8'));
+const plan = JSON.parse(fs.readFileSync(path.join(root, manifestPath), 'utf8'));
+const errors = validateWavePlan({ root, inventory, plan });
+if (errors.length > 0) {
+  console.error(`Migration wave ${plan.wave_id || '<unknown>'} failed validation:`);
+  errors.forEach(error => console.error(` - ${error}`));
+  process.exit(1);
+}
+console.log(`PASS: ${plan.wave_id} ${plan.phase} manifest has ${plan.asset_count} assets (limit ${plan.max_assets}).`);

--- a/tests/migration-wave.test.mjs
+++ b/tests/migration-wave.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import test from 'node:test';
 import { buildWavePlan, validateWavePlan } from '../scripts/lib/migration-wave.mjs';
 
@@ -18,12 +19,18 @@ function fixture(t) {
       { source: 'legacy/b.md', destination: 'domains/stakeholder/legacy/b.md', primary_domain: 'Stakeholder', secondary_domains: [], dependencies: ['legacy/a.md'], batch: 1, legacy_strategy: 'pointer', action: 'planned-move-not-executed' }
     ]
   };
-  return { root, inventory };
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'migration-wave-test@example.invalid'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Migration Wave Test'], { cwd: root });
+  execFileSync('git', ['add', '.'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'fixture'], { cwd: root });
+  const preBatchSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+  return { root, inventory, preBatchSha };
 }
 
 test('builds and validates a deterministic dependency-aware wave', t => {
-  const { root, inventory } = fixture(t);
-  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
   assert.equal(plan.asset_count, 2);
   assert.equal(plan.assets[0].source, 'legacy/a.md');
   assert.equal(plan.assets[1].dependencies[0].status, 'same-wave');
@@ -31,27 +38,27 @@ test('builds and validates a deterministic dependency-aware wave', t => {
 });
 
 test('rejects wave sizes above the safety ceiling', t => {
-  const { root, inventory } = fixture(t);
-  assert.throws(() => buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 16, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' }), /between 1 and 15/);
+  const { root, inventory, preBatchSha } = fixture(t);
+  assert.throws(() => buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 16, preBatchSha, rollbackOwner: 'owner' }), /between 1 and 15/);
 });
 
 test('detects source drift after the plan is generated', t => {
-  const { root, inventory } = fixture(t);
-  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
   fs.appendFileSync(path.join(root, 'legacy/a.md'), 'changed\n');
   assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /source hash mismatch/);
 });
 
 test('detects inventory snapshot drift after the plan is generated', t => {
-  const { root, inventory } = fixture(t);
-  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
   inventory.generated = '2026-09-08';
   assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /inventory_generated does not match migration inventory snapshot/);
 });
 
 test('validates the same manifest after an executed move', t => {
-  const { root, inventory } = fixture(t);
-  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha, rollbackOwner: 'owner' });
   const move = inventory.moves[0];
   fs.mkdirSync(path.join(root, 'domains/stakeholder/legacy'), { recursive: true });
   fs.renameSync(path.join(root, move.source), path.join(root, move.destination));
@@ -63,8 +70,8 @@ test('validates the same manifest after an executed move', t => {
 });
 
 test('validates canonical location link when other links exist', t => {
-  const { root, inventory } = fixture(t);
-  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha, rollbackOwner: 'owner' });
   const move = inventory.moves[0];
   fs.mkdirSync(path.join(root, 'domains/stakeholder/legacy'), { recursive: true });
   fs.renameSync(path.join(root, move.source), path.join(root, move.destination));
@@ -76,4 +83,39 @@ test('validates canonical location link when other links exist', t => {
   move.execution = { batch_id: 'B1F' };
   plan.phase = 'executed';
   assert.deepEqual(validateWavePlan({ root, inventory, plan }), []);
+});
+
+test('rejects a fabricated rollback checkpoint commit', t => {
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
+  plan.pre_batch_sha = 'f'.repeat(40);
+  assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /does not resolve to a commit/);
+});
+
+test('rejects a rollback checkpoint outside the current history', t => {
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
+  const emptyTree = execFileSync('git', ['mktree'], { cwd: root, input: '', encoding: 'utf8' }).trim();
+  plan.pre_batch_sha = execFileSync('git', ['commit-tree', emptyTree, '-m', 'unrelated'], { cwd: root, encoding: 'utf8' }).trim();
+  assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /is not an ancestor of HEAD/);
+});
+
+test('rejects incomplete checkpoints and rollback controls', t => {
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
+  plan.checkpoints = [];
+  plan.rollback.granularity = 'asset';
+  const errors = validateWavePlan({ root, inventory, plan }).join('\n');
+  assert.match(errors, /complete ordered checkpoint set/);
+  assert.match(errors, /rollback granularity must be wave/);
+});
+
+test('rejects altered dependency status and resolved path', t => {
+  const { root, inventory, preBatchSha } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha, rollbackOwner: 'owner' });
+  plan.assets[1].dependencies[0].status = 'satisfied-existing-deferred';
+  plan.assets[1].dependencies[0].resolved_path = plan.assets[1].dependencies[0].path;
+  const errors = validateWavePlan({ root, inventory, plan }).join('\n');
+  assert.match(errors, /dependency status mismatch/);
+  assert.match(errors, /dependency resolved path mismatch/);
 });

--- a/tests/migration-wave.test.mjs
+++ b/tests/migration-wave.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { buildWavePlan, validateWavePlan } from '../scripts/lib/migration-wave.mjs';
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-wave-'));
+  fs.mkdirSync(path.join(root, 'legacy'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'legacy/a.md'), '# A\n');
+  fs.writeFileSync(path.join(root, 'legacy/b.md'), '# B\n');
+  const inventory = {
+    generated: '2026-09-07',
+    moves: [
+      { source: 'legacy/a.md', destination: 'domains/stakeholder/legacy/a.md', primary_domain: 'Stakeholder', secondary_domains: [], dependencies: [], batch: 1, legacy_strategy: 'pointer', action: 'planned-move-not-executed' },
+      { source: 'legacy/b.md', destination: 'domains/stakeholder/legacy/b.md', primary_domain: 'Stakeholder', secondary_domains: [], dependencies: ['legacy/a.md'], batch: 1, legacy_strategy: 'pointer', action: 'planned-move-not-executed' }
+    ]
+  };
+  return { root, inventory };
+}
+
+test('builds and validates a deterministic dependency-aware wave', () => {
+  const { root, inventory } = fixture();
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  assert.equal(plan.asset_count, 2);
+  assert.equal(plan.assets[0].source, 'legacy/a.md');
+  assert.equal(plan.assets[1].dependencies[0].status, 'same-wave');
+  assert.deepEqual(validateWavePlan({ root, inventory, plan }), []);
+});
+
+test('rejects wave sizes above the safety ceiling', () => {
+  const { root, inventory } = fixture();
+  assert.throws(() => buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 16, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' }), /between 1 and 15/);
+});
+
+test('detects source drift after the plan is generated', () => {
+  const { root, inventory } = fixture();
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  fs.appendFileSync(path.join(root, 'legacy/a.md'), 'changed\n');
+  assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /source hash mismatch/);
+});
+
+test('validates the same manifest after an executed move', () => {
+  const { root, inventory } = fixture();
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const move = inventory.moves[0];
+  fs.mkdirSync(path.join(root, 'domains/stakeholder/legacy'), { recursive: true });
+  fs.renameSync(path.join(root, move.source), path.join(root, move.destination));
+  fs.writeFileSync(path.join(root, move.source), '# Moved\n\n[Canonical location](../domains/stakeholder/legacy/a.md)\n');
+  move.action = 'executed-move-with-legacy-pointer';
+  move.execution = { batch_id: 'B1F' };
+  plan.phase = 'executed';
+  assert.deepEqual(validateWavePlan({ root, inventory, plan }), []);
+});

--- a/tests/migration-wave.test.mjs
+++ b/tests/migration-wave.test.mjs
@@ -41,6 +41,13 @@ test('detects source drift after the plan is generated', () => {
   assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /source hash mismatch/);
 });
 
+test('detects inventory snapshot drift after the plan is generated', () => {
+  const { root, inventory } = fixture();
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  inventory.generated = '2026-09-08';
+  assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /inventory_generated does not match migration inventory snapshot/);
+});
+
 test('validates the same manifest after an executed move', () => {
   const { root, inventory } = fixture();
   const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });

--- a/tests/migration-wave.test.mjs
+++ b/tests/migration-wave.test.mjs
@@ -5,8 +5,9 @@ import path from 'node:path';
 import test from 'node:test';
 import { buildWavePlan, validateWavePlan } from '../scripts/lib/migration-wave.mjs';
 
-function fixture() {
+function fixture(t) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'migration-wave-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
   fs.mkdirSync(path.join(root, 'legacy'), { recursive: true });
   fs.writeFileSync(path.join(root, 'legacy/a.md'), '# A\n');
   fs.writeFileSync(path.join(root, 'legacy/b.md'), '# B\n');
@@ -20,8 +21,8 @@ function fixture() {
   return { root, inventory };
 }
 
-test('builds and validates a deterministic dependency-aware wave', () => {
-  const { root, inventory } = fixture();
+test('builds and validates a deterministic dependency-aware wave', t => {
+  const { root, inventory } = fixture(t);
   const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
   assert.equal(plan.asset_count, 2);
   assert.equal(plan.assets[0].source, 'legacy/a.md');
@@ -29,32 +30,48 @@ test('builds and validates a deterministic dependency-aware wave', () => {
   assert.deepEqual(validateWavePlan({ root, inventory, plan }), []);
 });
 
-test('rejects wave sizes above the safety ceiling', () => {
-  const { root, inventory } = fixture();
+test('rejects wave sizes above the safety ceiling', t => {
+  const { root, inventory } = fixture(t);
   assert.throws(() => buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 16, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' }), /between 1 and 15/);
 });
 
-test('detects source drift after the plan is generated', () => {
-  const { root, inventory } = fixture();
+test('detects source drift after the plan is generated', t => {
+  const { root, inventory } = fixture(t);
   const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
   fs.appendFileSync(path.join(root, 'legacy/a.md'), 'changed\n');
   assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /source hash mismatch/);
 });
 
-test('detects inventory snapshot drift after the plan is generated', () => {
-  const { root, inventory } = fixture();
+test('detects inventory snapshot drift after the plan is generated', t => {
+  const { root, inventory } = fixture(t);
   const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 12, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
   inventory.generated = '2026-09-08';
   assert.match(validateWavePlan({ root, inventory, plan }).join('\n'), /inventory_generated does not match migration inventory snapshot/);
 });
 
-test('validates the same manifest after an executed move', () => {
-  const { root, inventory } = fixture();
+test('validates the same manifest after an executed move', t => {
+  const { root, inventory } = fixture(t);
   const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
   const move = inventory.moves[0];
   fs.mkdirSync(path.join(root, 'domains/stakeholder/legacy'), { recursive: true });
   fs.renameSync(path.join(root, move.source), path.join(root, move.destination));
-  fs.writeFileSync(path.join(root, move.source), '# Moved\n\n[Canonical location](../domains/stakeholder/legacy/a.md)\n');
+  fs.writeFileSync(path.join(root, move.source), '# Moved\n\nCanonical location: [A](../domains/stakeholder/legacy/a.md)\n');
+  move.action = 'executed-move-with-legacy-pointer';
+  move.execution = { batch_id: 'B1F' };
+  plan.phase = 'executed';
+  assert.deepEqual(validateWavePlan({ root, inventory, plan }), []);
+});
+
+test('validates canonical location link when other links exist', t => {
+  const { root, inventory } = fixture(t);
+  const plan = buildWavePlan({ root, inventory, waveId: 'B1F', sourceBatch: 1, primaryDomain: 'Stakeholder', maxAssets: 1, preBatchSha: 'a'.repeat(40), rollbackOwner: 'owner' });
+  const move = inventory.moves[0];
+  fs.mkdirSync(path.join(root, 'domains/stakeholder/legacy'), { recursive: true });
+  fs.renameSync(path.join(root, move.source), path.join(root, move.destination));
+  fs.writeFileSync(
+    path.join(root, move.source),
+    '# Moved\n\n[Other](./README.md)\n\n**Canonical location:** [A](<../domains/stakeholder/legacy/a.md#section>)\n'
+  );
   move.action = 'executed-move-with-legacy-pointer';
   move.execution = { batch_id: 'B1F' };
   plan.phase = 'executed';


### PR DESCRIPTION
## Summary

Implements the reviewed migration-wave operating model for #1057 and parent #711.

- adds a deterministic, dependency-aware wave planner;
- adds entry/executed manifest validation with a hard 15-asset ceiling;
- records per-asset SHA-256 hashes, dependency dispositions, rollback ownership, and checkpoints;
- prevents wave planning manifests from creating generated inbound-reference drift;
- enforces planner tests and recorded-manifest validation in CI;
- documents affected-scope PR validation plus one comprehensive post-merge visual run;
- creates the entry-ready B1F definition for eight remaining Batch 1 Stakeholder assets.

## Safety model

The wave remains the production rollback boundary. Every asset retains its own source, destination, pre-move hash, dependency classification, and compatibility strategy. Missing dependencies, source drift, destination collisions, bad execution metadata, hash mismatches, or invalid legacy pointers fail validation.

The B1F manifest records one two-asset same-wave cycle; those assets must move atomically.

## Validation

- B1F entry manifest: PASS — 8 assets, Stakeholder domain, limit 12;
- migration-wave tests: 10/10 PASS, including rollback-SHA existence/ancestry, complete checkpoints, dependency evidence integrity, source/inventory drift, and executed-state validation;
- deterministic migration metadata: PASS — 137 records, 137/137 cross-reference coverage;
- Sprint 10 strict validation: PASS — 137/137, 100% coverage;
- curated templates: PASS — 139;
- canonical paths: PASS — 0 errors, 3 pre-existing warnings;
- filtered anchor links: PASS;
- focused Jest: PASS — 1 suite, 2 tests, 100% coverage;
- generated index: no drift;
- `git diff --check`: clean.

## Integration status

- All 16 applicable pull-request workflows passed on head `2f3c9d63`.
- CI run [34169973538](https://github.com/mirichard/pm-tools-templates/actions/runs/34169973538): passed, including 10 migration-wave tests and the strengthened recorded-manifest validation.
- Visual run [34169973570](https://github.com/mirichard/pm-tools-templates/actions/runs/34169973570): passed with zero regressions.
- Reviewed desktop and mobile baselines published atomically at `7201a765` on `visual-baselines`.
- No review findings or unresolved review threads.

## Scope boundary

This PR changes tooling, CI, documentation, and the proposed B1F entry manifest only. It performs no physical template moves. B1F execution will use a separate delivery PR after this change is integrated.

Contributes to #1057 and #711; does not close either issue.