### PR TITLE
feat(requirements-cli): generate-nfr command skeleton (#1112)

### DIFF
--- a/tools/requirements-structuring-cli/README.md
+++ b/tools/requirements-structuring-cli/README.md
@@ -168,6 +168,18 @@ artifact; classification (#1108) and generation (#1109) are follow-ups.
 See the [NFR input contract](docs/nfr-input-contract.md) for required fields,
 shape validation, and compatibility decisions. No version marker is required.
 
+```bash
+npm start -- generate-nfr --list-overlays
+npm start -- generate-nfr examples/web-store-ucs.json --profile neutral -o ./output
+```
+
+`--profile <name>` and `--overlay <name>` select the same registry entry. If both
+are supplied, they must agree. The default is `neutral` (no domain overlay);
+listing currently shows only `neutral core (default)`. Unknown names fail
+clearly. The empty registry in `src/nfr-overlays.js` is the selection boundary
+for #1115; this change includes no regulatory or other overlay content.
+Listing needs no input file or API credentials and writes no report.
+
 ### `validate <ucs-file>`
 
 Validate UCS consistency against activity diagrams and/or state machines (Algorithms 2 & 3).

--- a/tools/requirements-structuring-cli/README.md
+++ b/tools/requirements-structuring-cli/README.md
@@ -161,6 +161,13 @@ npm start generate-gherkin my-tests.json --ucs my-ucs.json -o my-feature.feature
 
 The `.feature` file can be wired directly into Cucumber, pytest-bdd, SpecFlow, or any Gherkin-compatible test framework.
 
+### `generate-nfr [input-file]`
+
+NFR command skeleton (#1112). Accepts an existing structured or UCS JSON
+artifact; classification (#1108) and generation (#1109) are follow-ups.
+See the [NFR input contract](docs/nfr-input-contract.md) for required fields,
+shape validation, and compatibility decisions. No version marker is required.
+
 ### `validate <ucs-file>`
 
 Validate UCS consistency against activity diagrams and/or state machines (Algorithms 2 & 3).

--- a/tools/requirements-structuring-cli/README.md
+++ b/tools/requirements-structuring-cli/README.md
@@ -180,6 +180,31 @@ clearly. The empty registry in `src/nfr-overlays.js` is the selection boundary
 for #1115; this change includes no regulatory or other overlay content.
 Listing needs no input file or API credentials and writes no report.
 
+The command writes `<base>-nfr-report.md` through the existing Markdown report
+writer, explicitly labeled `NFR generation not yet implemented (#1108/#1109)`.
+The stub does not call an LLM or create NFR candidates. `pipeline` automatically
+runs the same step after Phase 2 UCS, test cases and Gherkin, before the Phase 3
+review gate; all existing phase ordering and gates are preserved.
+
+| Flag | Behavior |
+| --- | --- |
+| `--provider gemini\|anthropic\|openai` | Override existing `LLM_PROVIDER` selection for the invocation; `openai` also covers compatible APIs using `LLM_BASE_URL`. |
+| `--model <name>` | Override existing `LLM_MODEL` selection for the invocation. |
+| `--attributes <names>` | Comma-separated non-empty names; trimmed/deduplicated and recorded without taxonomy lookup (#1115). |
+| `--confidence-threshold <number>` | Finite number in `[0, 1]`; recorded only, no confidence calculation or review gate. |
+| `--profile` / `--overlay` | Select an available name; default `neutral`. |
+| `-o` / `--output <dir>` | Report directory, default `./output`. Pipeline retains `--output-dir` and also accepts `--output`. |
+
+All these selection flags also apply to `pipeline`. Upstream pipeline phases
+still use the configured LLM and interactive gates. The standalone skeleton
+and overlay listing do not require API credentials. Provider/model flags reuse
+the existing environment loader/client and restore overrides after execution.
+
+```bash
+npm start -- generate-nfr examples/web-store-ucs.json --attributes reliability,security --confidence-threshold 0.8 -o ./output
+npm start -- pipeline examples/web-store-input.md --provider gemini --overlay neutral -o ./output
+```
+
 ### `validate <ucs-file>`
 
 Validate UCS consistency against activity diagrams and/or state machines (Algorithms 2 & 3).

--- a/tools/requirements-structuring-cli/docs/nfr-input-contract.md
+++ b/tools/requirements-structuring-cli/docs/nfr-input-contract.md
@@ -1,7 +1,8 @@
 # NFR Input Contract
 
 This document defines the input boundary for `generate-nfr` (#1112), used by
-classification (#1108) and generation (#1109). Implementation is in progress.
+classification (#1108) and generation (#1109). The contract is maintained in
+Git with `src/nfr-input.js`; it is not a version field in the input JSON.
 
 ## Design decisions
 
@@ -17,3 +18,51 @@ classification (#1108) and generation (#1109). Implementation is in progress.
 - Preserve the existing Commander, dotenv, LLMClient, report writer, phases,
   and interactive gates. Overlay content belongs to #1115; only neutral core
   is available in this skeleton.
+
+## Accepted artifacts and required fields
+
+The standalone command takes **one** JSON artifact, not a directory, raw
+requirements Markdown, test-case array, or an invented wrapper. The pipeline
+passes Phase 2 `ucs.toJSON()` after test-case/Gherkin generation, before the
+Phase 3 feedback gate. Existing Phases 0–5 and their order stay intact.
+
+| Artifact | Required shape |
+| --- | --- |
+| Phase 1 `*-structured.json` | Object with non-empty string `useCaseId`, non-empty string `useCaseName`, and non-empty `steps` array. |
+| Phase 2 `*-ucs.json` | Object with non-empty strings `useCaseId`, `intent`, `role`; `preconditions` and `postconditions` arrays of strings (empty allowed); `basicFlow` object with a non-empty `steps` array. |
+| Every step in either artifact | Object with non-empty strings `stepId`, `actor`, `action`, `businessObject`. |
+| UCS alternative/exception flow, when supplied | Object with non-empty strings `flowId`, `deviationPoint`, `triggerCondition`, and non-empty `steps` validated as above; optional string `rejoinPoint`. |
+
+UCS is identified by the presence of `basicFlow`, `intent`, or `role`; otherwise
+the document is interpreted as formal structure. A document with both UCS
+fields and top-level `steps` is rejected as ambiguous.
+
+Optional fields are preserved, not classified or rewritten:
+
+- Both: `businessObjects`, when present, must be an array of strings.
+- UCS: `useCaseName`, when present, must be a non-empty string;
+  `relatedUseCases` is an optional string array. `alternativeFlows` and
+  `exceptionFlows` are optional arrays (empty allowed).
+- Steps: `toActor`, `precondition`, `postcondition`, `refUseCaseId`, and
+  `description`, when present, must be strings. Formal steps also permit string
+  `previousStep`, `deviationPoint`, `rejoinPoint`, and `flowType` restricted to
+  `basic`, `alternative`, or `exception`.
+- Additional fields are retained subject to the existing JSON safety limits.
+  This boundary checks data shape, not 25010 taxonomy, flow semantics, or
+  classification/generation correctness.
+
+`useCaseName` is **not required for UCS** because the runtime model intentionally
+serializes `intent` instead. Requiring the sample's extra `useCaseName` would
+reject actual pipeline output. Formal structure still requires `useCaseName`
+as specified by `schemas/formal-structure.schema.json`. These decisions are
+part of the contract consumed by #1108/#1109.
+
+## Failure behavior
+
+Missing arguments/files fail with a missing-input message. Unreadable or
+malformed JSON fails with a file/JSON message. Unsafe JSON, wrong field types,
+empty required strings/step arrays, and ambiguous artifacts fail with an
+`Invalid NFR input` message identifying the boundary or field. All failures exit
+non-zero, before an NFR report is written. Re-run `structure` and `transform`
+(or `pipeline`) from the original requirements and correct upstream fields
+if they are still incomplete. No input file is modified.

--- a/tools/requirements-structuring-cli/docs/nfr-input-contract.md
+++ b/tools/requirements-structuring-cli/docs/nfr-input-contract.md
@@ -66,3 +66,26 @@ empty required strings/step arrays, and ambiguous artifacts fail with an
 non-zero, before an NFR report is written. Re-run `structure` and `transform`
 (or `pipeline`) from the original requirements and correct upstream fields
 if they are still incomplete. No input file is modified.
+
+## Legacy/pre-contract compatibility
+
+There is **no reliable artifact-age signal**: old and current outputs have no
+version marker. Complete v1.1.0 artifacts are accepted, including runtime UCS
+without `useCaseName`. Do not add a version field to make an input pass.
+
+The concrete legacy/incomplete signals, after JSON safety validation, are:
+
+1. A recognized UCS object (non-empty `useCaseId` and at least one of
+   `intent`, `role`, `basicFlow`, without top-level `steps`) is missing
+   `basicFlow` or `basicFlow.steps`, or has a bare `basicFlow` array rather
+   than `{ "steps": [...] }`.
+2. A recognized formal structure (non-empty `useCaseId`, a `useCaseName`
+   property, no UCS discriminator) is missing the top-level `steps` property.
+
+These fail distinctly with `Legacy/incomplete NFR input (pre-contract shape)`
+and instructions to re-run structuring/transformation. They identify an
+incompatible shape, **not proof that a file is old**; a newly incomplete file
+can trigger the same message. Present-but-invalid fields (for example
+`steps: null`, an empty step array, or a step missing `action`) remain ordinary
+contract-validation errors. Missing UCS `useCaseName` never triggers either
+error. No legacy input is silently migrated or modified.

--- a/tools/requirements-structuring-cli/docs/nfr-input-contract.md
+++ b/tools/requirements-structuring-cli/docs/nfr-input-contract.md
@@ -1,0 +1,19 @@
+# NFR Input Contract
+
+This document defines the input boundary for `generate-nfr` (#1112), used by
+classification (#1108) and generation (#1109). Implementation is in progress.
+
+## Design decisions
+
+- Reuse the Phase 1 `*-structured.json` and Phase 2 `*-ucs.json` artifacts.
+  Validate their fields directly: neither currently carries a version marker,
+  and this feature will neither require nor add one.
+- UCS `useCaseName` is **not required**. `UCSTemplate.toJSON()` omits it;
+  `intent` supplies the context and `useCaseId` supplies identity. Formal
+  structure retains its existing required `useCaseName` field.
+- Legacy/pre-contract detection will use missing required structural fields,
+  not a missing version or an inferred creation date. Complete existing
+  artifacts remain valid regardless of age.
+- Preserve the existing Commander, dotenv, LLMClient, report writer, phases,
+  and interactive gates. Overlay content belongs to #1115; only neutral core
+  is available in this skeleton.

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -37,6 +37,7 @@ const GherkinGenerator = require('./gherkin-generator');
 const NFRGenerator = require('./nfr-generator');
 const { addNFROptions, normalizeNFROptions, configureNFRProvider } = require('./nfr-options');
 const { loadNFRInput } = require('./nfr-input');
+const { listOverlays } = require('./nfr-overlays');
 
 function terminalLog(message) {
   const safeMessage = sanitizeTerminalValue(message);
@@ -319,11 +320,17 @@ program
 addNFROptions(program.command('generate-nfr [input-file]'))
   .description('Run the NFR command skeleton on structured requirements or UCS JSON')
   .option('-o, --output <dir>', 'Output directory', './output')
+  .option('--list-overlays', 'List available overlays without reading input or calling an LLM')
   .action(async (inputFile, opts) => {
     const spinner = ora('Loading NFR input...').start();
     let restoreProvider = () => {};
     try {
       const options = normalizeNFROptions(opts);
+      if (opts.listOverlays) {
+        spinner.stop();
+        for (const overlay of listOverlays()) terminalLog(overlay.label);
+        return;
+      }
       restoreProvider = configureNFRProvider(options);
       const input = await loadNFRInput(inputFile);
       const generator = new NFRGenerator();

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -36,6 +36,7 @@ const AmbiguityDetector = require('./ambiguity-detector');
 const GherkinGenerator = require('./gherkin-generator');
 const NFRGenerator = require('./nfr-generator');
 const { addNFROptions, normalizeNFROptions, configureNFRProvider } = require('./nfr-options');
+const { loadNFRInput } = require('./nfr-input');
 
 function terminalLog(message) {
   const safeMessage = sanitizeTerminalValue(message);
@@ -315,7 +316,7 @@ program
   });
 
 // ─── generate-nfr ────────────────────────────────────────────────────────────
-addNFROptions(program.command('generate-nfr <input-file>'))
+addNFROptions(program.command('generate-nfr [input-file]'))
   .description('Run the NFR command skeleton on structured requirements or UCS JSON')
   .option('-o, --output <dir>', 'Output directory', './output')
   .action(async (inputFile, opts) => {
@@ -324,7 +325,7 @@ addNFROptions(program.command('generate-nfr <input-file>'))
     try {
       const options = normalizeNFROptions(opts);
       restoreProvider = configureNFRProvider(options);
-      const input = await fs.readJSON(path.resolve(inputFile));
+      const input = await loadNFRInput(inputFile);
       const generator = new NFRGenerator();
       const result = await generator.run(input, options);
       spinner.succeed('NFR skeleton complete');

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -429,6 +429,12 @@ program
       await gherkin.generateFile(testCases, ucsJSON2, safeFeaturePath);
       terminalLog(chalk.dim(`  → ${safeFeaturePath} (Gherkin/BDD)`));
 
+      // ═══ NFR Phase: after UCS, test cases and Gherkin ═════════════════════
+      terminalLog(chalk.blue.bold('\n═══ NFR Phase ═══'));
+      const nfrGenerator = new NFRGenerator();
+      const nfrResult = await nfrGenerator.run(ucsJSON2, { output: outputDir, baseName });
+      terminalLog(chalk.yellow(nfrResult.notice));
+
       const { proceed: proceed2 } = await inquirer.prompt([
         { type: 'confirm', name: 'proceed', message: 'Review complete. Proceed to Phase 3?', default: true },
       ]);

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -34,6 +34,7 @@ const FeedbackLoop = require('./feedback-loop');
 const ReportGenerator = require('./report-generator');
 const AmbiguityDetector = require('./ambiguity-detector');
 const GherkinGenerator = require('./gherkin-generator');
+const NFRGenerator = require('./nfr-generator');
 
 function terminalLog(message) {
   const safeMessage = sanitizeTerminalValue(message);
@@ -306,6 +307,25 @@ program
       await gherkin.generateFile(testCases, ucs, safeOutputPath);
       spinner.succeed('Gherkin feature file generated');
       terminalLog(chalk.green(`✓ Feature file saved to ${safeOutputPath}`));
+    } catch (err) {
+      spinnerFail(spinner, err && err.message ? err.message : String(err));
+      process.exit(1);
+    }
+  });
+
+// ─── generate-nfr ────────────────────────────────────────────────────────────
+program
+  .command('generate-nfr <input-file>')
+  .description('Run the NFR command skeleton on structured requirements or UCS JSON')
+  .option('-o, --output <dir>', 'Output directory', './output')
+  .action(async (inputFile, opts) => {
+    const spinner = ora('Loading NFR input...').start();
+    try {
+      const input = await fs.readJSON(path.resolve(inputFile));
+      const generator = new NFRGenerator();
+      const result = await generator.run(input, opts);
+      spinner.succeed('NFR skeleton complete');
+      terminalLog(chalk.yellow(result.notice));
     } catch (err) {
       spinnerFail(spinner, err && err.message ? err.message : String(err));
       process.exit(1);

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -555,7 +555,8 @@ addNFROptions(program.command('pipeline <input-file>'))
       terminalLog(chalk.cyan('\n  BDD/Gherkin:'));
       terminalLog(chalk.cyan(`    • ${baseName}.feature`));
     } catch (err) {
-      terminalError(chalk.red(`Pipeline error: ${sanitizeErrorPayload(err && err.message ? err.message : String(err))}`));
+      const diagnostic = sanitizeErrorPayload(err && err.message ? err.message : String(err));
+      terminalError(chalk.red(`Pipeline error: ${diagnostic.message || 'Unknown error'}`));
       process.exitCode = 1;
     } finally {
       restoreProvider();

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -35,6 +35,7 @@ const ReportGenerator = require('./report-generator');
 const AmbiguityDetector = require('./ambiguity-detector');
 const GherkinGenerator = require('./gherkin-generator');
 const NFRGenerator = require('./nfr-generator');
+const { addNFROptions, normalizeNFROptions, configureNFRProvider } = require('./nfr-options');
 
 function terminalLog(message) {
   const safeMessage = sanitizeTerminalValue(message);
@@ -314,38 +315,42 @@ program
   });
 
 // ─── generate-nfr ────────────────────────────────────────────────────────────
-program
-  .command('generate-nfr <input-file>')
+addNFROptions(program.command('generate-nfr <input-file>'))
   .description('Run the NFR command skeleton on structured requirements or UCS JSON')
   .option('-o, --output <dir>', 'Output directory', './output')
   .action(async (inputFile, opts) => {
     const spinner = ora('Loading NFR input...').start();
+    let restoreProvider = () => {};
     try {
+      const options = normalizeNFROptions(opts);
+      restoreProvider = configureNFRProvider(options);
       const input = await fs.readJSON(path.resolve(inputFile));
       const generator = new NFRGenerator();
-      const result = await generator.run(input, opts);
+      const result = await generator.run(input, options);
       spinner.succeed('NFR skeleton complete');
       terminalLog(chalk.yellow(result.notice));
     } catch (err) {
       spinnerFail(spinner, err && err.message ? err.message : String(err));
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      restoreProvider();
     }
   });
 
 // ─── pipeline ────────────────────────────────────────────────────────────────
-program
-  .command('pipeline <input-file>')
+addNFROptions(program.command('pipeline <input-file>'))
   .description('Full 5-phase pipeline per Li & Zheng (2025)')
   .option('--activity <file>', 'Business process model JSON')
   .option('--state <files...>', 'State model JSON file(s)')
   .option('-o, --output-dir <dir>', 'Output directory', './output')
   .action(async (inputFile, opts) => {
-    const outputDir = buildSafeOutputPath(opts.outputDir);
-    await fs.ensureDir(outputDir);
-
-    const baseName = path.basename(inputFile, path.extname(inputFile));
-
+    let restoreProvider = () => {};
     try {
+      const nfrOptions = normalizeNFROptions(opts);
+      restoreProvider = configureNFRProvider(nfrOptions);
+      const outputDir = buildSafeOutputPath(opts.outputDir);
+      await fs.ensureDir(outputDir);
+      const baseName = path.basename(inputFile, path.extname(inputFile));
       // ═══ Phase 0: Ambiguity Detection ═══════════════════════════════════════
       terminalLog(chalk.blue.bold('\n═══ Phase 0: Ambiguity Detection ═══'));
       const rawContent = await fs.readFile(path.resolve(inputFile), 'utf-8');
@@ -432,7 +437,7 @@ program
       // ═══ NFR Phase: after UCS, test cases and Gherkin ═════════════════════
       terminalLog(chalk.blue.bold('\n═══ NFR Phase ═══'));
       const nfrGenerator = new NFRGenerator();
-      const nfrResult = await nfrGenerator.run(ucsJSON2, { output: outputDir, baseName });
+      const nfrResult = await nfrGenerator.run(ucsJSON2, { ...nfrOptions, output: outputDir, baseName });
       terminalLog(chalk.yellow(nfrResult.notice));
 
       const { proceed: proceed2 } = await inquirer.prompt([
@@ -538,7 +543,9 @@ program
       terminalLog(chalk.cyan(`    • ${baseName}.feature`));
     } catch (err) {
       terminalError(chalk.red(`Pipeline error: ${sanitizeErrorPayload(err && err.message ? err.message : String(err))}`));
-      process.exit(1);
+      process.exitCode = 1;
+    } finally {
+      restoreProvider();
     }
   });
 

--- a/tools/requirements-structuring-cli/src/index.js
+++ b/tools/requirements-structuring-cli/src/index.js
@@ -334,9 +334,11 @@ addNFROptions(program.command('generate-nfr [input-file]'))
       restoreProvider = configureNFRProvider(options);
       const input = await loadNFRInput(inputFile);
       const generator = new NFRGenerator();
-      const result = await generator.run(input, options);
+      const baseName = path.basename(inputFile, path.extname(inputFile)).replace(/-(?:structured|ucs)(?:-refined)?$/, '');
+      const result = await generator.run(input, { ...options, baseName });
       spinner.succeed('NFR skeleton complete');
       terminalLog(chalk.yellow(result.notice));
+      terminalLog(chalk.green(`✓ NFR placeholder report saved to ${result.reportPath}`));
     } catch (err) {
       spinnerFail(spinner, err && err.message ? err.message : String(err));
       process.exitCode = 1;
@@ -351,12 +353,13 @@ addNFROptions(program.command('pipeline <input-file>'))
   .option('--activity <file>', 'Business process model JSON')
   .option('--state <files...>', 'State model JSON file(s)')
   .option('-o, --output-dir <dir>', 'Output directory', './output')
+  .option('--output <dir>', 'Alias for --output-dir')
   .action(async (inputFile, opts) => {
     let restoreProvider = () => {};
     try {
       const nfrOptions = normalizeNFROptions(opts);
       restoreProvider = configureNFRProvider(nfrOptions);
-      const outputDir = buildSafeOutputPath(opts.outputDir);
+      const outputDir = buildSafeOutputPath(opts.output || opts.outputDir);
       await fs.ensureDir(outputDir);
       const baseName = path.basename(inputFile, path.extname(inputFile));
       // ═══ Phase 0: Ambiguity Detection ═══════════════════════════════════════
@@ -447,6 +450,7 @@ addNFROptions(program.command('pipeline <input-file>'))
       const nfrGenerator = new NFRGenerator();
       const nfrResult = await nfrGenerator.run(ucsJSON2, { ...nfrOptions, output: outputDir, baseName });
       terminalLog(chalk.yellow(nfrResult.notice));
+      terminalLog(chalk.dim(`  → ${nfrResult.reportPath}`));
 
       const { proceed: proceed2 } = await inquirer.prompt([
         { type: 'confirm', name: 'proceed', message: 'Review complete. Proceed to Phase 3?', default: true },
@@ -536,6 +540,7 @@ addNFROptions(program.command('pipeline <input-file>'))
         outputDir,
         baseName,
       });
+      reportFiles.push(nfrResult.reportPath);
 
       for (const f of reportFiles) {
         terminalLog(chalk.dim(`  → ${f}`));

--- a/tools/requirements-structuring-cli/src/nfr-generator.js
+++ b/tools/requirements-structuring-cli/src/nfr-generator.js
@@ -3,14 +3,17 @@
  * Classification (#1108) and generation (#1109) are not yet implemented.
  */
 const LLMClient = require('./llm-client');
+const { validateNFRInput } = require('./nfr-input');
 
 class NFRGenerator {
   async run(input, options = {}) {
+    const { kind, data } = validateNFRInput(input);
     const llm = new LLMClient();
     return {
       status: 'not-implemented',
       notice: 'NFR generation not yet implemented (#1108/#1109)',
-      input,
+      input: data,
+      inputKind: kind,
       options: { ...options, provider: llm.provider, model: llm.model },
     };
   }

--- a/tools/requirements-structuring-cli/src/nfr-generator.js
+++ b/tools/requirements-structuring-cli/src/nfr-generator.js
@@ -4,18 +4,26 @@
  */
 const LLMClient = require('./llm-client');
 const { validateNFRInput } = require('./nfr-input');
+const { normalizeNFROptions } = require('./nfr-options');
+const ReportGenerator = require('./report-generator');
 
 class NFRGenerator {
   async run(input, options = {}) {
     const { kind, data } = validateNFRInput(input);
     const llm = new LLMClient();
-    return {
+    const result = {
       status: 'not-implemented',
       notice: 'NFR generation not yet implemented (#1108/#1109)',
       input: data,
       inputKind: kind,
-      options: { ...options, provider: llm.provider, model: llm.model },
+      options: { ...normalizeNFROptions(options), provider: llm.provider, model: llm.model },
     };
+    const reportGenerator = new ReportGenerator();
+    result.reportPath = await reportGenerator.generateNFRReport(result, {
+      outputDir: options.output || './output',
+      baseName: options.baseName || 'requirements',
+    });
+    return result;
   }
 }
 

--- a/tools/requirements-structuring-cli/src/nfr-generator.js
+++ b/tools/requirements-structuring-cli/src/nfr-generator.js
@@ -1,0 +1,16 @@
+/**
+ * NFR command skeleton (#1112).
+ * Classification (#1108) and generation (#1109) are not yet implemented.
+ */
+class NFRGenerator {
+  async run(input, options = {}) {
+    return {
+      status: 'not-implemented',
+      notice: 'NFR generation not yet implemented (#1108/#1109)',
+      input,
+      options,
+    };
+  }
+}
+
+module.exports = NFRGenerator;

--- a/tools/requirements-structuring-cli/src/nfr-generator.js
+++ b/tools/requirements-structuring-cli/src/nfr-generator.js
@@ -2,13 +2,16 @@
  * NFR command skeleton (#1112).
  * Classification (#1108) and generation (#1109) are not yet implemented.
  */
+const LLMClient = require('./llm-client');
+
 class NFRGenerator {
   async run(input, options = {}) {
+    const llm = new LLMClient();
     return {
       status: 'not-implemented',
       notice: 'NFR generation not yet implemented (#1108/#1109)',
       input,
-      options,
+      options: { ...options, provider: llm.provider, model: llm.model },
     };
   }
 }

--- a/tools/requirements-structuring-cli/src/nfr-input.js
+++ b/tools/requirements-structuring-cli/src/nfr-input.js
@@ -19,6 +19,22 @@ function strings(value, field) {
   }
 }
 
+function guardLegacyShape(data) {
+  if (typeof data.useCaseId !== 'string' || !data.useCaseId.trim()) return;
+  const isUCS = own(data, 'basicFlow') || own(data, 'intent') || own(data, 'role');
+  let missing;
+  if (isUCS && !own(data, 'steps')) {
+    if (!own(data, 'basicFlow')) missing = 'basicFlow.steps is missing';
+    else if (Array.isArray(data.basicFlow)) missing = 'basicFlow is a bare array instead of an object with steps';
+    else if (object(data.basicFlow) && !own(data.basicFlow, 'steps')) missing = 'basicFlow.steps is missing';
+  } else if (!isUCS && own(data, 'useCaseName') && !own(data, 'steps')) {
+    missing = 'structured steps is missing';
+  }
+  if (missing) {
+    throw new Error(`Legacy/incomplete NFR input (pre-contract shape): ${missing}. Re-run structure and transform (or pipeline) from the original requirements; do not add a version marker. See docs/nfr-input-contract.md.`);
+  }
+}
+
 function steps(value, field, structured = false) {
   if (!Array.isArray(value) || !value.length) invalid(field, 'must be a non-empty array');
   value.forEach((step, index) => {
@@ -43,6 +59,7 @@ function validateNFRInput(input) {
   } catch {
     invalid('document', 'must be a safe JSON object within the existing CLI size/depth limits');
   }
+  guardLegacyShape(data);
   text(data.useCaseId, 'useCaseId');
   const isUCS = own(data, 'basicFlow') || own(data, 'intent') || own(data, 'role');
   if (isUCS && own(data, 'steps')) invalid('document', 'must contain one artifact, not both structured and UCS shapes');

--- a/tools/requirements-structuring-cli/src/nfr-input.js
+++ b/tools/requirements-structuring-cli/src/nfr-input.js
@@ -1,0 +1,95 @@
+const fs = require('fs-extra');
+const path = require('path');
+const { validateStructuredResponse } = require('./security');
+
+const own = (value, key) => Object.prototype.hasOwnProperty.call(value, key);
+const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+function invalid(field, expectation) {
+  throw new Error(`Invalid NFR input: ${field} ${expectation}. Re-run structure and transform (or pipeline) from the original requirements; see docs/nfr-input-contract.md.`);
+}
+
+function text(value, field) {
+  if (typeof value !== 'string' || !value.trim()) invalid(field, 'must be a non-empty string');
+}
+
+function strings(value, field) {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    invalid(field, 'must be an array of strings');
+  }
+}
+
+function steps(value, field, structured = false) {
+  if (!Array.isArray(value) || !value.length) invalid(field, 'must be a non-empty array');
+  value.forEach((step, index) => {
+    const location = `${field}[${index}]`;
+    if (!object(step)) invalid(location, 'must be an object');
+    for (const key of ['stepId', 'actor', 'action', 'businessObject']) text(step[key], `${location}.${key}`);
+    for (const key of ['toActor', 'precondition', 'postcondition', 'refUseCaseId', 'description',
+      ...(structured ? ['previousStep', 'deviationPoint', 'rejoinPoint'] : [])]) {
+      if (own(step, key) && typeof step[key] !== 'string') invalid(`${location}.${key}`, 'must be a string');
+    }
+    if (structured && own(step, 'flowType') && !['basic', 'alternative', 'exception'].includes(step.flowType)) {
+      invalid(`${location}.flowType`, 'must be basic, alternative, or exception');
+    }
+  });
+}
+
+function validateNFRInput(input) {
+  let data;
+  try {
+    // Reuse the CLI's JSON safety boundary before interpreting domain fields.
+    data = validateStructuredResponse(JSON.stringify(input), { expectedRoot: 'object' });
+  } catch {
+    invalid('document', 'must be a safe JSON object within the existing CLI size/depth limits');
+  }
+  text(data.useCaseId, 'useCaseId');
+  const isUCS = own(data, 'basicFlow') || own(data, 'intent') || own(data, 'role');
+  if (isUCS && own(data, 'steps')) invalid('document', 'must contain one artifact, not both structured and UCS shapes');
+
+  if (isUCS) {
+    text(data.intent, 'intent');
+    text(data.role, 'role');
+    if (own(data, 'useCaseName')) text(data.useCaseName, 'useCaseName');
+    strings(data.preconditions, 'preconditions');
+    strings(data.postconditions, 'postconditions');
+    if (!object(data.basicFlow)) invalid('basicFlow', 'must be an object containing steps');
+    steps(data.basicFlow.steps, 'basicFlow.steps');
+    for (const key of ['alternativeFlows', 'exceptionFlows']) {
+      if (!own(data, key)) continue;
+      if (!Array.isArray(data[key])) invalid(key, 'must be an array');
+      data[key].forEach((flow, index) => {
+        const location = `${key}[${index}]`;
+        if (!object(flow)) invalid(location, 'must be an object');
+        for (const field of ['flowId', 'deviationPoint', 'triggerCondition']) text(flow[field], `${location}.${field}`);
+        steps(flow.steps, `${location}.steps`);
+        if (own(flow, 'rejoinPoint') && typeof flow.rejoinPoint !== 'string') invalid(`${location}.rejoinPoint`, 'must be a string');
+      });
+    }
+    if (own(data, 'relatedUseCases')) strings(data.relatedUseCases, 'relatedUseCases');
+  } else {
+    text(data.useCaseName, 'useCaseName');
+    steps(data.steps, 'steps', true);
+  }
+  if (own(data, 'businessObjects')) strings(data.businessObjects, 'businessObjects');
+  return { kind: isUCS ? 'ucs' : 'structured', data };
+}
+
+async function loadNFRInput(inputFile) {
+  if (!inputFile) {
+    throw new Error('Missing NFR input: provide a structured or UCS JSON file. Run structure and transform (or pipeline) first.');
+  }
+  let input;
+  try {
+    input = await fs.readJSON(path.resolve(inputFile));
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      throw new Error('Missing NFR input file. Check the path and run structure and transform (or pipeline) first.');
+    }
+    throw new Error('Unable to read NFR input as JSON. Check file permissions and use a structured or UCS JSON artifact; see docs/nfr-input-contract.md.');
+  }
+  validateNFRInput(input);
+  return input;
+}
+
+module.exports = { validateNFRInput, loadNFRInput };

--- a/tools/requirements-structuring-cli/src/nfr-options.js
+++ b/tools/requirements-structuring-cli/src/nfr-options.js
@@ -1,4 +1,5 @@
 const { InvalidArgumentError } = require('commander');
+const { selectOverlay } = require('./nfr-overlays');
 
 function nonEmpty(value) {
   if (!value.trim()) throw new InvalidArgumentError('Expected a non-empty value.');
@@ -48,7 +49,7 @@ function normalizeNFROptions(options) {
     ...options,
     attributes: options.attributes || [],
     confidenceThreshold: options.confidenceThreshold ?? null,
-    overlay: options.overlay || options.profile || 'neutral',
+    overlay: selectOverlay(options.overlay || options.profile || 'neutral'),
   };
 }
 

--- a/tools/requirements-structuring-cli/src/nfr-options.js
+++ b/tools/requirements-structuring-cli/src/nfr-options.js
@@ -1,0 +1,69 @@
+const { InvalidArgumentError } = require('commander');
+
+function nonEmpty(value) {
+  if (!value.trim()) throw new InvalidArgumentError('Expected a non-empty value.');
+  return value.trim();
+}
+
+function parseAttributes(value) {
+  const attributes = value.split(',').map((entry) => entry.trim());
+  if (attributes.some((entry) => !entry)) {
+    throw new InvalidArgumentError('--attributes requires a comma-separated list without empty entries.');
+  }
+  // Taxonomy membership is owned by #1115, not this command skeleton.
+  return [...new Set(attributes)];
+}
+
+function parseConfidence(value) {
+  const threshold = Number(value);
+  if (!value.trim() || !Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+    throw new InvalidArgumentError('--confidence-threshold must be a finite number between 0 and 1.');
+  }
+  return threshold;
+}
+
+function parseProvider(value) {
+  const provider = nonEmpty(value).toLowerCase();
+  if (!['gemini', 'anthropic', 'openai'].includes(provider)) {
+    throw new InvalidArgumentError('--provider must be gemini, anthropic, or openai (including compatible APIs).');
+  }
+  return provider;
+}
+
+function addNFROptions(command) {
+  return command
+    .option('--provider <name>', 'LLM provider (uses existing environment configuration)', parseProvider)
+    .option('--model <name>', 'Override the configured LLM model', nonEmpty)
+    .option('--attributes <names>', 'Comma-separated attribute subset (stored for #1108)', parseAttributes)
+    .option('--confidence-threshold <number>', 'Review threshold from 0 to 1 (stored for #1111)', parseConfidence)
+    .option('--profile <name>', 'Domain overlay profile (alias for --overlay)', nonEmpty)
+    .option('--overlay <name>', 'Domain overlay name; default is neutral core', nonEmpty);
+}
+
+function normalizeNFROptions(options) {
+  if (options.profile && options.overlay && options.profile !== options.overlay) {
+    throw new Error('--profile and --overlay must select the same name when both are supplied.');
+  }
+  return {
+    ...options,
+    attributes: options.attributes || [],
+    confidenceThreshold: options.confidenceThreshold ?? null,
+    overlay: options.overlay || options.profile || 'neutral',
+  };
+}
+
+// Keep provider/model resolution in LLMClient; flags override its existing env
+// inputs only for this invocation. Restore them even if an action fails.
+function configureNFRProvider(options) {
+  const previous = { LLM_PROVIDER: process.env.LLM_PROVIDER, LLM_MODEL: process.env.LLM_MODEL };
+  if (options.provider) process.env.LLM_PROVIDER = options.provider;
+  if (options.model) process.env.LLM_MODEL = options.model;
+  return () => {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  };
+}
+
+module.exports = { addNFROptions, normalizeNFROptions, configureNFRProvider };

--- a/tools/requirements-structuring-cli/src/nfr-overlays.js
+++ b/tools/requirements-structuring-cli/src/nfr-overlays.js
@@ -1,0 +1,17 @@
+/** Selection metadata only. Curated overlay content/registration belongs to #1115. */
+const OVERLAY_REGISTRY = Object.freeze({});
+
+function listOverlays() {
+  return [
+    { name: 'neutral', label: 'neutral core (default)' },
+    ...Object.entries(OVERLAY_REGISTRY).map(([name, entry]) => ({ name, label: entry.label })),
+  ];
+}
+
+function selectOverlay(name = 'neutral') {
+  if (name === 'neutral') return 'neutral';
+  if (Object.prototype.hasOwnProperty.call(OVERLAY_REGISTRY, name)) return name;
+  throw new Error(`Unknown NFR overlay: ${name}. Run generate-nfr --list-overlays. Only neutral core is available until #1115 supplies overlay content.`);
+}
+
+module.exports = { listOverlays, selectOverlay };

--- a/tools/requirements-structuring-cli/src/report-generator.js
+++ b/tools/requirements-structuring-cli/src/report-generator.js
@@ -8,9 +8,48 @@
 
 const fs = require('fs-extra');
 const path = require('path');
-const { safeWriteText, buildSafeOutputPath, buildContainedChildPath } = require('./security');
+const { safeWriteText, buildSafeOutputPath, buildContainedChildPath, sanitizeTerminalValue } = require('./security');
 
 class ReportGenerator {
+  /** Write a deliberately non-generative report through the existing text sink. */
+  async generateNFRReport(result, { outputDir, baseName }) {
+    const safeOutputDir = buildSafeOutputPath(outputDir);
+    await fs.ensureDir(safeOutputDir);
+    const reportPath = buildContainedChildPath(safeOutputDir, `${baseName}-nfr-report.md`);
+    await safeWriteText(reportPath, this.formatNFRReport(result), 'utf8', { rootDir: safeOutputDir });
+    return reportPath;
+  }
+
+  formatNFRReport({ notice, input, inputKind, options }) {
+    const display = (value) => sanitizeTerminalValue(value);
+    return [
+      `# NFR Report: ${display(input.useCaseId)}`,
+      '',
+      '**Status: Placeholder — not implemented**',
+      '',
+      notice,
+      '',
+      'No classification, NFR candidates, confidence scores, or overlay content were produced.',
+      '',
+      '## Input',
+      '',
+      `- Artifact: ${inputKind}`,
+      `- Use case: ${display(input.useCaseName || input.intent || input.useCaseId)}`,
+      '',
+      '## Requested Options',
+      '',
+      `- Provider: ${display(options.provider || 'not configured (no LLM call)')}`,
+      `- Model: ${display(options.model)}`,
+      `- Attributes: ${options.attributes.length ? options.attributes.map(display).join(', ') : 'unspecified'}`,
+      `- Confidence threshold: ${options.confidenceThreshold ?? 'unspecified'}`,
+      `- Overlay: ${display(options.overlay)} (neutral core; no overlay content)`,
+      '',
+      'These options are recorded only. Classification (#1108), generation (#1109),',
+      'the review gate (#1111), and the curated library (#1115) are follow-ups.',
+      '',
+    ].join('\n');
+  }
+
   /**
    * Generate all Markdown reports from pipeline artifacts
    * @param {object} opts

--- a/tools/requirements-structuring-cli/tests/nfr-pipeline-fixture.js
+++ b/tools/requirements-structuring-cli/tests/nfr-pipeline-fixture.js
@@ -1,0 +1,72 @@
+/** Test-only preload: replace remote LLM stages/prompts, exercise the real CLI. */
+const fs = require('fs-extra');
+const sample = require('../examples/web-store-ucs.json');
+const { UCSTemplate } = require('../src/ucs-template');
+const LLMClient = require('../src/llm-client');
+const AmbiguityDetector = require('../src/ambiguity-detector');
+const RequirementsStructurer = require('../src/structurer');
+const UCSTransformer = require('../src/ucs-transformer');
+const TestGenerator = require('../src/test-generator');
+const GherkinGenerator = require('../src/gherkin-generator');
+const NFRGenerator = require('../src/nfr-generator');
+const FeedbackLoop = require('../src/feedback-loop');
+const ConsistencyChecker = require('../src/consistency-checker');
+const inquirer = require('inquirer');
+
+function record(event, detail = {}) {
+  if (process.env.NFR_TEST_EVENTS) {
+    fs.appendFileSync(process.env.NFR_TEST_EVENTS, JSON.stringify({ event, ...detail }) + '\n');
+  }
+}
+
+LLMClient.prototype.chat = async () => { throw new Error('Unexpected LLM call in offline NFR test'); };
+AmbiguityDetector.prototype.detect = async function () {
+  record('ambiguity');
+  const gate = process.env.NFR_TEST_GATE;
+  return { findings: [], summary: { blockers: 0, warnings: 0,
+    readinessScore: gate === 'not_ready' ? 'not_ready' : gate === 'clarification' ? 'needs_clarification' : 'ready' } };
+};
+RequirementsStructurer.prototype.structure = async function () {
+  record('structure', { provider: this.llm.provider, model: this.llm.model });
+  return { useCaseId: sample.useCaseId, useCaseName: sample.useCaseName, steps: sample.basicFlow.steps };
+};
+UCSTransformer.prototype.transform = async function () {
+  record('ucs');
+  return UCSTemplate.fromJSON(sample);
+};
+const generateTests = TestGenerator.prototype.generate;
+TestGenerator.prototype.generate = function (...args) {
+  record('tests');
+  return generateTests.apply(this, args);
+};
+const generateGherkin = GherkinGenerator.prototype.generateFile;
+GherkinGenerator.prototype.generateFile = async function (...args) {
+  record('gherkin');
+  return generateGherkin.apply(this, args);
+};
+const generateNFR = NFRGenerator.prototype.run;
+NFRGenerator.prototype.run = async function (input, options) {
+  record('nfr', { hasUseCaseName: Object.prototype.hasOwnProperty.call(input, 'useCaseName'),
+    attributes: options.attributes, threshold: options.confidenceThreshold, overlay: options.overlay });
+  return generateNFR.call(this, input, options);
+};
+FeedbackLoop.prototype.run = async function (ucs) {
+  record('feedback');
+  return { updatedUCS: ucs, suggestions: [] };
+};
+for (const [method, event] of [['validateWithProcess', 'activity'], ['validateWithState', 'state']]) {
+  const original = ConsistencyChecker.prototype[method];
+  ConsistencyChecker.prototype[method] = function (...args) {
+    record(event);
+    return original.apply(this, args);
+  };
+}
+inquirer.prompt = async (questions) => {
+  const question = questions[0];
+  record('gate', { message: question.message });
+  const gate = process.env.NFR_TEST_GATE;
+  const decline = gate === 'clarification' ||
+    (gate === 'phase1' && question.message.includes('Phase 2')) ||
+    (gate === 'phase2' && question.message.includes('Phase 3'));
+  return { [question.name]: !decline };
+};

--- a/tools/requirements-structuring-cli/tests/nfr-tests.js
+++ b/tools/requirements-structuring-cli/tests/nfr-tests.js
@@ -1,0 +1,257 @@
+const assert = require('assert');
+const fs = require('fs-extra');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { Command } = require('commander');
+const { UCSTemplate } = require('../src/ucs-template');
+const { validateNFRInput } = require('../src/nfr-input');
+const { addNFROptions, normalizeNFROptions, configureNFRProvider } = require('../src/nfr-options');
+const { listOverlays } = require('../src/nfr-overlays');
+const LLMClient = require('../src/llm-client');
+const TestGenerator = require('../src/test-generator');
+const GherkinGenerator = require('../src/gherkin-generator');
+
+module.exports = async function testNFR(runner) {
+  const root = path.resolve(__dirname, '..');
+  const temp = await fs.mkdtemp(path.join(__dirname, '.nfr-test-'));
+  const sample = await fs.readJSON(path.join(root, 'examples/web-store-ucs.json'));
+  const runtime = UCSTemplate.fromJSON(sample).toJSON();
+  const structured = { useCaseId: 'UC-01', useCaseName: 'Checkout', steps: sample.basicFlow.steps };
+  const runtimePath = path.join(temp, 'runtime-ucs.json');
+  const structuredPath = path.join(temp, 'formal-structured.json');
+  await fs.writeJSON(runtimePath, runtime);
+  await fs.writeJSON(structuredPath, structured);
+  const test = (description, fn) => runner.test(description, async () => { await fn(); return true; });
+  const copy = (data) => JSON.parse(JSON.stringify(data));
+  const parse = (args) => {
+    const command = addNFROptions(new Command()).exitOverride().configureOutput({ writeErr() {} });
+    command.parse(args, { from: 'user' });
+    return normalizeNFROptions(command.opts());
+  };
+  const cli = (args, extra = {}) => {
+    const env = { ...process.env, LLM_PROVIDER: '', LLM_MODEL: '', LLM_API_KEY: '',
+      GEMINI_API_KEY: '', ANTHROPIC_API_KEY: '', OPENAI_API_KEY: '', SAVE_LLM_TRACES: 'false',
+      ...extra.env };
+    const child = spawnSync(process.execPath,
+      [...(extra.preload ? ['--require', path.join(__dirname, 'nfr-pipeline-fixture.js')] : []),
+        path.join(root, 'src/index.js'), ...args],
+      { cwd: temp, env, encoding: 'utf8', timeout: 15000 });
+    if (child.error) throw child.error;
+    return { ...child, text: child.stdout + child.stderr };
+  };
+  const failedCLI = async (name, payload, pattern) => {
+    const input = path.join(temp, `${name}.json`);
+    const output = path.join(temp, `${name}-output`);
+    await fs.writeJSON(input, payload);
+    const result = cli(['generate-nfr', input, '-o', output]);
+    assert.strictEqual(result.status, 1, result.text);
+    assert.match(result.text, pattern);
+    assert.strictEqual(await fs.pathExists(output), false);
+  };
+  try {
+    await test('NFR command and all pre-existing commands remain registered', () => {
+      const result = cli(['--help']);
+      assert.strictEqual(result.status, 0, result.text);
+      for (const name of ['init', 'detect', 'structure', 'transform', 'generate-tests', 'validate',
+        'review', 'generate-gherkin', 'generate-nfr', 'pipeline']) assert.ok(result.stdout.includes(name));
+    });
+    await test('NFR help exposes all requested flags', () => {
+      const result = cli(['generate-nfr', '--help']);
+      assert.strictEqual(result.status, 0, result.text);
+      for (const flag of ['--provider', '--model', '--attributes', '--confidence-threshold',
+        '--profile', '--overlay', '--list-overlays', '--output']) assert.ok(result.stdout.includes(flag));
+    });
+    await test('NFR parses and stores provider, model, attributes, threshold and aliases', () => {
+      const options = parse(['--provider', 'GEMINI', '--model', 'custom-model', '--attributes', 'reliability, security,reliability',
+        '--confidence-threshold', '0.75', '--profile', 'neutral', '--overlay', 'neutral']);
+      assert.strictEqual(options.provider, 'gemini');
+      assert.strictEqual(options.model, 'custom-model');
+      assert.deepStrictEqual(options.attributes, ['reliability', 'security']);
+      assert.strictEqual(options.confidenceThreshold, 0.75);
+      assert.strictEqual(options.overlay, 'neutral');
+    });
+    await test('NFR defaults to neutral without inventing attributes or scores', () => {
+      const options = parse([]);
+      assert.strictEqual(options.overlay, 'neutral');
+      assert.deepStrictEqual(options.attributes, []);
+      assert.strictEqual(options.confidenceThreshold, null);
+      assert.strictEqual(options.provider, undefined);
+    });
+    await test('NFR rejects malformed attributes, thresholds, providers and empty models', () => {
+      for (const args of [ ['--attributes', 'a,,b'], ['--attributes', ' '],
+        ['--confidence-threshold', 'NaN'], ['--confidence-threshold', 'Infinity'],
+        ['--confidence-threshold', '-0.1'], ['--confidence-threshold', '1.1'],
+        ['--confidence-threshold', ' '], ['--provider', 'unsupported'], ['--model', ' ']]) {
+        assert.throws(() => parse(args));
+      }
+      assert.strictEqual(parse(['--confidence-threshold', '0']).confidenceThreshold, 0);
+      assert.strictEqual(parse(['--confidence-threshold', '1']).confidenceThreshold, 1);
+    });
+    await test('NFR rejects conflicting or unknown profiles including inherited object keys', () => {
+      assert.throws(() => parse(['--profile', 'neutral', '--overlay', 'other']), /must select the same/);
+      for (const flag of ['--profile', '--overlay']) {
+        for (const name of ['unknown', 'constructor', '__proto__', 'toString']) {
+          assert.throws(() => parse([flag, name]), /Unknown NFR overlay/);
+        }
+      }
+    });
+    await test('NFR provider overrides reuse LLMClient and restore environment', () => {
+      const previous = { provider: process.env.LLM_PROVIDER, model: process.env.LLM_MODEL };
+      const restore = configureNFRProvider({ provider: 'anthropic', model: 'fixture-model' });
+      try {
+        const llm = new LLMClient();
+        assert.strictEqual(llm.provider, 'anthropic');
+        assert.strictEqual(llm.model, 'fixture-model');
+      } finally { restore(); }
+      assert.strictEqual(process.env.LLM_PROVIDER, previous.provider);
+      assert.strictEqual(process.env.LLM_MODEL, previous.model);
+    });
+    await test('NFR accepts existing structured data without adding version markers', () => {
+      const result = validateNFRInput(structured);
+      assert.strictEqual(result.kind, 'structured');
+      assert.deepStrictEqual(result.data, structured);
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(result.data, 'version'), false);
+    });
+    await test('NFR accepts real runtime UCS without useCaseName or version', () => {
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(runtime, 'useCaseName'), false);
+      assert.deepStrictEqual(validateNFRInput(runtime).data, runtime);
+      assert.strictEqual(validateNFRInput(sample).kind, 'ucs');
+    });
+    await test('NFR validates nested steps and optional fields across both artifacts', () => {
+      const badStep = copy(runtime); delete badStep.basicFlow.steps[0].action;
+      assert.throws(() => validateNFRInput(badStep), /basicFlow.steps\[0\].action/);
+      const badFlow = copy(runtime); badFlow.exceptionFlows[0].steps = [];
+      assert.throws(() => validateNFRInput(badFlow), /exceptionFlows\[0\].steps/);
+      const badCondition = copy(runtime); badCondition.preconditions = 'logged in';
+      assert.throws(() => validateNFRInput(badCondition), /preconditions/);
+      const badObjects = copy(structured); badObjects.businessObjects = [123];
+      assert.throws(() => validateNFRInput(badObjects), /businessObjects/);
+      const badType = copy(structured); badType.steps[0].flowType = 'other';
+      assert.throws(() => validateNFRInput(badType), /flowType/);
+      const noName = copy(structured); delete noName.useCaseName;
+      assert.throws(() => validateNFRInput(noName), /useCaseName/);
+    });
+    await test('NFR rejects ambiguous artifacts, unsafe roots and prohibited keys', () => {
+      assert.throws(() => validateNFRInput({ ...runtime, steps: [] }), /both structured and UCS/);
+      for (const data of [null, [], 'text', JSON.parse('{"__proto__":{}}')]) {
+        assert.throws(() => validateNFRInput(data), /Invalid NFR input/);
+      }
+    });
+    await test('NFR detects concrete pre-contract step-container shapes', () => {
+      const cases = [ { useCaseId: 'UC-01', useCaseName: 'Old' },
+        { useCaseId: 'UC-01', intent: 'Old', role: 'User' },
+        { ...runtime, basicFlow: {} }, { ...runtime, basicFlow: runtime.basicFlow.steps } ];
+      for (const data of cases) assert.throws(() => validateNFRInput(data), /Legacy\/incomplete NFR input.*Re-run structure/);
+    });
+    await test('NFR distinguishes invalid present fields from legacy missing containers', () => {
+      assert.throws(() => validateNFRInput({ ...structured, steps: null }), /^Error: Invalid NFR input/);
+      assert.throws(() => validateNFRInput({ ...runtime, basicFlow: { steps: [] } }), /^Error: Invalid NFR input/);
+      const before = JSON.stringify(runtime);
+      validateNFRInput(runtime);
+      assert.strictEqual(JSON.stringify(runtime), before);
+    });
+    await test('NFR overlay registry and CLI listing expose only neutral core', async () => {
+      assert.deepStrictEqual(listOverlays(), [{ name: 'neutral', label: 'neutral core (default)' }]);
+      const output = path.join(temp, 'list-output');
+      const result = cli(['generate-nfr', '--list-overlays', '-o', output]);
+      assert.strictEqual(result.status, 0, result.text);
+      assert.strictEqual(result.stdout.split('\n').filter((line) => line.includes('(default)')).join(''), 'neutral core (default)');
+      assert.strictEqual(await fs.pathExists(output), false);
+    });
+    await test('NFR standalone produces a placeholder from runtime UCS without credentials', async () => {
+      const output = path.join(temp, 'standalone');
+      const result = cli(['generate-nfr', runtimePath, '--attributes', 'security,reliability',
+        '--confidence-threshold', '0.8', '--profile', 'neutral', '--provider', 'openai', '--model', 'fixture-model', '--output', output]);
+      assert.strictEqual(result.status, 0, result.text);
+      const report = await fs.readFile(path.join(output, 'runtime-nfr-report.md'), 'utf8');
+      for (const fragment of ['NFR generation not yet implemented (#1108/#1109)', 'Artifact: ucs',
+        'security, reliability', '0.8', 'openai', 'fixture-model', 'neutral', 'No classification, NFR candidates']) {
+        assert.ok(report.includes(fragment), fragment);
+      }
+      assert.deepStrictEqual(await fs.readJSON(runtimePath), runtime);
+    });
+    await test('NFR standalone also consumes the formal structure artifact', async () => {
+      const output = path.join(temp, 'formal');
+      const result = cli(['generate-nfr', structuredPath, '--overlay', 'neutral', '-o', output]);
+      assert.strictEqual(result.status, 0, result.text);
+      assert.match(await fs.readFile(path.join(output, 'formal-nfr-report.md'), 'utf8'), /Artifact: structured/);
+    });
+    await test('NFR missing argument or file fails non-zero with an actionable message', () => {
+      for (const args of [[], [path.join(temp, 'absent.json')]]) {
+        const result = cli(['generate-nfr', ...args]);
+        assert.strictEqual(result.status, 1, result.text);
+        assert.match(result.text, /Missing NFR input.*(Run|run) structure/);
+      }
+    });
+    await test('NFR malformed JSON fails clearly before writing a report', async () => {
+      const input = path.join(temp, 'malformed.json');
+      await fs.writeFile(input, '{bad');
+      const result = cli(['generate-nfr', input]);
+      assert.strictEqual(result.status, 1, result.text);
+      assert.match(result.text, /Unable to read NFR input as JSON/);
+    });
+    await test('NFR invalid schema fails non-zero without output', async () => {
+      await failedCLI('invalid', { ...structured, steps: [] }, /Invalid NFR input: steps/);
+    });
+    await test('NFR legacy shape fails non-zero with re-structuring instructions', async () => {
+      await failedCLI('legacy', { useCaseId: 'UC-01', useCaseName: 'Old' }, /Legacy\/incomplete NFR input.*Re-run structure/);
+    });
+    await test('NFR invalid flags fail non-zero before reading input', () => {
+      for (const args of [['--confidence-threshold', '2'], ['--provider', 'invalid'],
+        ['--profile', 'unknown'], ['--profile', 'neutral', '--overlay', 'other']]) {
+        const result = cli(['generate-nfr', ...args]);
+        assert.strictEqual(result.status, 1, result.text);
+        assert.doesNotMatch(result.text, /Missing NFR input/);
+      }
+    });
+    await test('NFR pipeline runs after UCS/tests/Gherkin and preserves subsequent phases', async () => {
+      const output = path.join(temp, 'pipeline');
+      const eventsPath = path.join(temp, 'events.jsonl');
+      const result = cli(['pipeline', path.join(root, 'examples/web-store-input.md'),
+        '--activity', path.join(root, 'examples/web-store-activity.json'),
+        '--state', path.join(root, 'examples/web-store-state.json'),
+        '--provider', 'gemini', '--model', 'pipeline-fixture', '--attributes', 'security',
+        '--confidence-threshold', '0.6', '--overlay', 'neutral', '--output', output],
+      { preload: true, env: { NFR_TEST_EVENTS: eventsPath } });
+      assert.strictEqual(result.status, 0, result.text);
+      assert.match(result.text, /Pipeline complete/);
+      const events = (await fs.readFile(eventsPath, 'utf8')).trim().split('\n').map(JSON.parse);
+      assert.deepStrictEqual(events.map((entry) => entry.event),
+        ['ambiguity', 'structure', 'gate', 'ucs', 'tests', 'gherkin', 'nfr', 'gate', 'feedback', 'activity', 'state', 'activity', 'state']);
+      assert.deepStrictEqual(events.find((entry) => entry.event === 'structure'),
+        { event: 'structure', provider: 'gemini', model: 'pipeline-fixture' });
+      assert.deepStrictEqual(events.find((entry) => entry.event === 'nfr'),
+        { event: 'nfr', hasUseCaseName: false, attributes: ['security'], threshold: 0.6, overlay: 'neutral' });
+      const base = path.join(output, 'web-store-input');
+      assert.deepStrictEqual(await fs.readJSON(base + '-ucs.json'), runtime);
+      const expectedTests = new TestGenerator().generate(runtime);
+      assert.deepStrictEqual(await fs.readJSON(base + '-tests.json'), expectedTests);
+      assert.strictEqual(await fs.readFile(base + '.feature', 'utf8'), new GherkinGenerator().generate(expectedTests, runtime));
+      for (const suffix of ['-ambiguity-report.md', '-use-case-spec.md', '-test-cases.md', '-summary.md', '-validation-report.md', '-nfr-report.md']) {
+        assert.ok(await fs.pathExists(base + suffix), suffix);
+      }
+    });
+    await test('NFR insertion preserves all existing early-exit review gates', async () => {
+      for (const gate of ['not_ready', 'clarification', 'phase1', 'phase2']) {
+        const output = path.join(temp, 'gate-' + gate);
+        const eventsPath = path.join(temp, gate + '.jsonl');
+        const result = cli(['pipeline', path.join(root, 'examples/web-store-input.md'), '-o', output],
+          { preload: true, env: { NFR_TEST_EVENTS: eventsPath, NFR_TEST_GATE: gate } });
+        assert.strictEqual(result.status, 0, result.text);
+        const events = (await fs.readFile(eventsPath, 'utf8')).trim().split('\n').map(JSON.parse);
+        assert.strictEqual(events.some((entry) => entry.event === 'feedback'), false);
+        assert.strictEqual(events.some((entry) => entry.event === 'nfr'), gate === 'phase2');
+        if (['not_ready', 'clarification'].includes(gate)) assert.strictEqual(events.some((entry) => entry.event === 'structure'), false);
+      }
+    });
+    await test('Pipeline validates overlay selection before any upstream LLM stage', async () => {
+      const output = path.join(temp, 'unknown-pipeline');
+      const result = cli(['pipeline', path.join(root, 'examples/web-store-input.md'), '--overlay', 'unknown', '-o', output]);
+      assert.strictEqual(result.status, 1, result.text);
+      assert.match(result.text, /Unknown NFR overlay/);
+      assert.strictEqual(await fs.pathExists(output), false);
+    });
+  } finally {
+    await fs.remove(temp);
+  }
+};

--- a/tools/requirements-structuring-cli/tests/test-runner.js
+++ b/tools/requirements-structuring-cli/tests/test-runner.js
@@ -40,6 +40,7 @@ class TestRunner {
     await this.testAmbiguityDetector();
     await this.testGherkinGenerator();
     await this.testSecurityBoundaries();
+    await require('./nfr-tests')(this);
 
     this.printResults();
   }


### PR DESCRIPTION
Part of #1107. Implements the scoped #1112 command skeleton, input contract, and overlay-selection plumbing.

Adds `generate-nfr` and an NFR phase after UCS/test-case/Gherkin generation. Both write a clearly labeled placeholder Markdown report through the existing report utilities. Provider/model flags reuse existing configuration; attributes and confidence threshold are recorded for follow-up work. Overlay selection/listing currently exposes only neutral core.

The input contract validates existing structured/UCS fields directly, with no version marker. UCS `useCaseName` is optional because runtime serialization omits it; `intent` provides context. Concrete missing/incompatible step-container shapes produce distinct legacy/incomplete-input guidance. These decisions are documented in `docs/nfr-input-contract.md`.

Classification (#1108), NFR generation (#1109), confidence/review logic (#1111), and overlay content (#1115) remain follow-ups.

Validation: `npm test` passes 67/67 (43 existing + 24 new), including standalone reports, flags, missing/invalid/legacy input errors, neutral-only listing, and the full pipeline with offline LLM/review doubles. Existing pipeline ordering, gates, and artifacts are checked; no live-provider pipeline run was performed.

Scope verification: merge-base diff from 0970338f8441608a189d45c97e89ed300a5d2975 and GitHub PR file list agree on 11 files, all under `tools/requirements-structuring-cli`; `git diff --check` passes. Original 10 commits preserved; no rebase or merge.

Progress and verification: https://github.com/mirichard/pm-tools-templates/issues/1112#issuecomment-5625206555