### PR TITLE
fix: enforce migration post-check after merge

### DIFF
--- a/.github/workflows/migration-post-check.yml
+++ b/.github/workflows/migration-post-check.yml
@@ -6,6 +6,10 @@ on:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
     types: [created, edited, deleted]
+  push:
+    branches: [main]
+  issues:
+    types: [closed]
   workflow_dispatch:
 
 permissions:
@@ -15,6 +19,7 @@ permissions:
 
 jobs:
   migration-post-check:
+    if: github.event_name != 'issues' || github.event.issue.number == 1057
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +53,7 @@ jobs:
           fi
 
       - name: Reject unresolved review threads at merge boundary
-        if: github.event_name != 'workflow_dispatch'
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' || github.event_name == 'pull_request_review_comment'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Closes the post-merge enforcement gap discovered immediately after #1129 merged: #1057 was auto-closed even though planned migration moves remain, while Migration Post-Check did not run on `main` pushes.

## Changes

- Run Migration Post-Check on pushes to `main`.
- Run it when issue #1057 is closed, while skipping the job for unrelated issue closures.
- Restrict unresolved-review-thread inspection to PR/review events that actually contain PR context.
- Preserve the existing fail-closed #1057 invariant: if planned moves remain, #1057 must be OPEN.

## Scope

Safeguard-only correction. No template bodies, migration inventory, catalogs, mappings, or B3C assets are changed.

Related to #1057. Keep #1057 open until the remaining migration denominator reaches zero.