### PR TITLE
fix: self-heal migration parent issue closure

### DIFF
--- a/.github/workflows/migration-post-check.yml
+++ b/.github/workflows/migration-post-check.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
 
 jobs:
@@ -49,6 +49,11 @@ jobs:
           remaining=$(node -e "const i=require('./meta/migration-inventory.json'); console.log(i.moves.filter(m=>m.action==='planned-move-not-executed').length)")
           if [ "$remaining" -gt 0 ]; then
             state=$(gh issue view 1057 --repo "$GITHUB_REPOSITORY" --json state --jq .state)
+            if [ "$state" != "OPEN" ] && [ "${{ github.event_name }}" = "issues" ] && [ "${{ github.event.issue.number || 0 }}" = "1057" ]; then
+              echo "#1057 was closed with $remaining migration move(s) remaining; reopening it."
+              gh issue reopen 1057 --repo "$GITHUB_REPOSITORY"
+              state=$(gh issue view 1057 --repo "$GITHUB_REPOSITORY" --json state --jq .state)
+            fi
             test "$state" = "OPEN" || { echo "#1057 must remain open while $remaining moves remain"; exit 1; }
           fi
 


### PR DESCRIPTION
## Summary

Completes the #1057 open-state safeguard after production verification of #1130 showed the detector works but does not recover the issue state.

Production evidence: issue-triggered Migration Post-Check run `34717950178` fired when #1057 was closed with migration work remaining and failed as designed. The missing behavior was recovery: #1057 stayed closed.

## Changes

- Grant this workflow `issues: write` so it can repair the protected migration-parent state.
- When the `issues: closed` event is specifically #1057 and planned moves remain, reopen #1057 automatically.
- Re-read the issue state after reopening and still fail closed unless it is OPEN.
- Preserve detector-only/fail-closed behavior for push, PR, review, and manual runs; those events do not mutate issue state.
- Preserve the existing job-level filter for unrelated issue closures.

## Scope

Safeguard-only correction. No template bodies, migration inventory, catalogs, mappings, migration evidence, or B3C assets are changed.

Addresses #1057. Do not close #1057 until the remaining migration denominator reaches zero.